### PR TITLE
Update process_param.f90

### DIFF
--- a/route/build/src/process_param.f90
+++ b/route/build/src/process_param.f90
@@ -56,23 +56,33 @@ contains
   ! ---------------------------------------------------------------------------------------
   ! initialize error control
   ierr=0; message='basinUH/'
-  ! use a Gamma distribution with shape parameter, fshape = 2.5, and time parameter, tscale, input
+  ! use a Gamma distribution with shape parameter, fshape, and time parameter, tscale, input
   alamb = fshape/tscale                  ! scale parameter
   ! find the desired number of future time steps
-  ntdh_min = 1._dp
-  ntdh_max = 1000._dp
-  ntdh_try = 0.5_dp*(ntdh_min + ntdh_max)
-  do itry=1,maxtry
-   x_value = alamb*dt*ntdh_try
-   cumprob = gammp(fshape, x_value)
-   !print*, tscale, ntdh_try, cumprob
-   if(cumprob < 0.99_dp)  ntdh_min = ntdh_try
-   if(cumprob > 0.999_dp) ntdh_max = ntdh_try
-   if(cumprob > 0.99_dp .and. cumprob < 0.999_dp) exit
-   ntdh_try = 0.5_dp*(ntdh_min + ntdh_max)
-   if(itry==maxtry)then; ierr=20; message=trim(message)//'cannot identify the maximum number of bins for the tdh'; return; endif
-  end do
+  ! in case check if the cummulative Gamma distribution is 1 for given model time step, tscale and fsahpe.
+  ! Modified by Shervan Gharari on 23th July 2019
+  X_VALUE = alamb*dt                        ! assuming ntdh_try is set to 1.00
+  cumprob = gammp(fshape, X_VALUE)          ! check the cumdist gamma distribution for the X_VALUE of UH of 1 time step
+  if(cumprob > 0.999_dp) then               ! check if the cum dist function reaches close to one for UH of 1 time step
+   print*, cumprob, X_VALUE                 ! print the value of X_VALUE
+   ntdh_try = 1.5                           ! to make sure that we have 2.00 time step for UH one will be with [1.00,0.00]
+  else                                      ! if the sum is not one then find the best UH length by itterating from a large number
+   ntdh_min = 1._dp
+   ntdh_max = 1000._dp
+   ntdh_try = 0.5_dp*(ntdh_min + ntdh_max)  
+   do itry=1,maxtry
+    x_value = alamb*dt*ntdh_try
+    cumprob = gammp(fshape, x_value)
+    print*, tscale, ntdh_try, cumprob, x_value, itry
+    if(cumprob < 0.99_dp)  ntdh_min = ntdh_try
+    if(cumprob > 0.999_dp) ntdh_max = ntdh_try
+    if(cumprob > 0.99_dp .and. cumprob < 0.999_dp) exit
+    ntdh_try = 0.5_dp*(ntdh_min + ntdh_max)
+    if(itry==maxtry)then; ierr=20; message=trim(message)//'cannot identify the maximum number of bins for the tdh'; return; endif
+   end do
+  endif                                    ! end the if statement
   ntdh = ceiling(ntdh_try)
+  print*, ntdh                             ! print the ntdh
   ! allocate space for the time-delay histogram
   if (.not.allocated(FRAC_FUTURE)) then
     allocate(FRAC_FUTURE(ntdh), stat=ierr)

--- a/route/build/src/process_param.f90
+++ b/route/build/src/process_param.f90
@@ -59,30 +59,29 @@ contains
   ! use a Gamma distribution with shape parameter, fshape, and time parameter, tscale, input
   alamb = fshape/tscale                  ! scale parameter
   ! find the desired number of future time steps
-  ! in case check if the cummulative Gamma distribution is 1 for given model time step, tscale and fsahpe.
-  ! Modified by Shervan Gharari on 23th July 2019
-  X_VALUE = alamb*dt                        ! assuming ntdh_try is set to 1.00
-  cumprob = gammp(fshape, X_VALUE)          ! check the cumdist gamma distribution for the X_VALUE of UH of 1 time step
-  if(cumprob > 0.999_dp) then               ! check if the cum dist function reaches close to one for UH of 1 time step
-   print*, cumprob, X_VALUE                 ! print the value of X_VALUE
-   ntdh_try = 1.5                           ! to make sure that we have 2.00 time step for UH one will be with [1.00,0.00]
-  else                                      ! if the sum is not one then find the best UH length by itterating from a large number
+  ! check if the cummulative Gamma distribution is close to 1.00 for given model time step, tscale and fsahpe.
+  X_VALUE = alamb*dt
+  cumprob = gammp(fshape, X_VALUE)
+  if(cumprob > 0.999_dp) then
+   !print*, cumprob, X_VALUE
+   ntdh_try = 1.999_dp
+  else
    ntdh_min = 1._dp
    ntdh_max = 1000._dp
    ntdh_try = 0.5_dp*(ntdh_min + ntdh_max)  
    do itry=1,maxtry
     x_value = alamb*dt*ntdh_try
     cumprob = gammp(fshape, x_value)
-    print*, tscale, ntdh_try, cumprob, x_value, itry
+    !print*, tscale, ntdh_try, cumprob, x_value, itry
     if(cumprob < 0.99_dp)  ntdh_min = ntdh_try
     if(cumprob > 0.999_dp) ntdh_max = ntdh_try
     if(cumprob > 0.99_dp .and. cumprob < 0.999_dp) exit
     ntdh_try = 0.5_dp*(ntdh_min + ntdh_max)
     if(itry==maxtry)then; ierr=20; message=trim(message)//'cannot identify the maximum number of bins for the tdh'; return; endif
    end do
-  endif                                    ! end the if statement
+  endif
   ntdh = ceiling(ntdh_try)
-  print*, ntdh                             ! print the ntdh
+  !print*, ntdh
   ! allocate space for the time-delay histogram
   if (.not.allocated(FRAC_FUTURE)) then
     allocate(FRAC_FUTURE(ntdh), stat=ierr)


### PR DESCRIPTION
The change takes care of the case if the shape function and time scale are less than the modelling time step. if the UH are less than the modelling time step they set the UH length to 1. This was creating problems for the previous implementation. I have tested it with my set up; for daily it set UH length to 1 and for hourly simulation it set it to 4 or 5 hours which is actually what is should do...