### PR TITLE
Feature/mpi pio.gptl.minorfix

### DIFF
--- a/route/build/src/domain_decomposition.f90
+++ b/route/build/src/domain_decomposition.f90
@@ -56,8 +56,6 @@ CONTAINS
 
    ierr=0; message='mpi_domain_decomposition/'
 
-   if (nNodes==1) return
-
    call classify_river_basin(nNodes,         &        ! input:  number of procs
                              nSeg,           &        ! input:  number of reaches in the entire river network
                              structNTOPO,    &        ! input:  river network data structure

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -89,9 +89,10 @@ module globalData
 
   integer(i4b)                   , public :: mpicom_route              ! communicator for this program
   integer(i4b)                   , public :: pid                       ! process id
-  integer(i4b)                   , public :: nNodes                    ! number of nodes
+  integer(i4b)                   , public :: nNodes                    ! number of MPI processors
   integer(i4b)                   , public :: nThreads                  ! number of threads
   logical(lgt)                   , public :: masterproc                ! root logical. root processor => true, other => false
+  logical(lgt)                   , public :: multiProcs                ! MPI multi-processors logical. => number of processors>1 true, other => false
   character(len=strLen)          , public :: pio_netcdf_format = "64bit_offset"
   character(len=strLen)          , public :: pio_typename      = "pnetcdf"
   integer(i4b)                   , public :: pio_numiotasks    = -99

--- a/route/build/src/mpi_process.f90
+++ b/route/build/src/mpi_process.f90
@@ -751,8 +751,8 @@ contains
     call t_stopf ('route/scatter-runoff')
   else
      if (masterproc) then
-       write(iulog,*) 'NOTE: HRU Runoff is already decomposed into mainstems and tributaries. No need for scatter_runoff'
        if (.not.allocated(basinRunoff_main)) then
+         write(iulog,*) 'NOTE: HRU Runoff is already decomposed into mainstems and tributaries. No need for scatter_runoff'
          ierr=10; message=trim(message)//'mainstem runoff array is not allocated/populated'; return
        endif
      else

--- a/route/build/src/mpi_process.f90
+++ b/route/build/src/mpi_process.f90
@@ -750,8 +750,8 @@ contains
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     call t_stopf ('route/scatter-runoff')
   else
-     write(iulog,*) 'Runoff data is already decomposed into mainstem and tributaries'
      if (masterproc) then
+       write(iulog,*) 'NOTE: HRU Runoff is already decomposed into mainstems and tributaries. No need for scatter_runoff'
        if (.not.allocated(basinRunoff_main)) then
          ierr=10; message=trim(message)//'mainstem runoff array is not allocated/populated'; return
        endif

--- a/route/build/src/mpi_process.f90
+++ b/route/build/src/mpi_process.f90
@@ -1942,8 +1942,6 @@ contains
   USE globalData, ONLY: startJulday       ! julian day: start
   USE globalData, ONLY: endJulday         ! julian day: end
   USE globalData, ONLY: modJulday         ! julian day: at simulation time step
-  USE globalData, ONLY: length_conv
-  USE globalData, ONLY: time_conv
   USE globalData, ONLY: reachID
   USE globalData, ONLY: basinID
   implicit none
@@ -1968,8 +1966,6 @@ contains
   call MPI_BCAST(startJulday, 1,     MPI_DOUBLE_PRECISION, root, comm, ierr)
   call MPI_BCAST(endJulday,   1,     MPI_DOUBLE_PRECISION, root, comm, ierr)
   call MPI_BCAST(modJulday,   1,     MPI_DOUBLE_PRECISION, root, comm, ierr)
-  call MPI_BCAST(length_conv, 1,     MPI_DOUBLE_PRECISION, root, comm, ierr)
-  call MPI_BCAST(time_conv,   1,     MPI_DOUBLE_PRECISION, root, comm, ierr)
 
   call shr_mpi_bcast(timeVar,ierr, message)
   call shr_mpi_bcast(reachID,ierr, message)

--- a/route/build/src/network_topo.f90
+++ b/route/build/src/network_topo.f90
@@ -147,6 +147,9 @@ contains
  ! loop through HRUs
  do iHRU=1,nHRU
 
+  ! save the HRU index
+  structHRU2seg(iHRU)%var(ixHRU2SEG%HRUindex)%dat(1) = iHRU
+
   ! identify the index of the stream segment that the HRU drains into
   iSeg = segHRUix(iHRU)
 
@@ -167,9 +170,6 @@ contains
 
   ! end associations
   end associate
-
-  ! save the HRU index
-  structHRU2seg(iHRU)%var(ixHRU2SEG%HRUindex)%dat(1) = iHRU
 
  end do ! looping through HRUs
 

--- a/route/build/src/standalone/route_runoff.f90
+++ b/route/build/src/standalone/route_runoff.f90
@@ -18,8 +18,8 @@ USE globalData, ONLY: mpicom_route            ! communicator
 ! provide access to desired subroutines...
 ! ****************************************
 ! subroutines: model set up
-USE perf_mod,            ONLY: t_initf          ! initialize timing routines
-USE perf_mod,            ONLY: t_startf,t_stopf ! timing start/stop
+USE perf_mod,            ONLY: t_initf          ! initialize timing routines (GPTL library)
+USE perf_mod,            ONLY: t_startf,t_stopf ! timing start/stop (GPTL library)
 USE model_setup,         ONLY: init_mpi         ! initialize MPI for this program
 USE model_setup,         ONLY: init_data        ! initialize river reach data
 USE init_model_data,     ONLY: init_model       ! model setupt - reading control file, populate metadata, read parameter file


### PR DESCRIPTION
1.  Use logical variables - multiProcs and masterproc.   multiProc is logical to indicate the code is using single task (F) or mult tasks (T) in MPI. masterproc indicate the task is master proc (T) or child proc (F). 
2. Improved code flow in domain decompositions (dependent on MPI single task or multiple task). 
3. For Coupling mode: Define HRU decomposition array (ixHRU_order ) that is required in coupling mode even if single MPI task is used.   
3. For Coupling mode: Check basinRunoff array is allocated for no runoff scattering option (i.e, coupling mode). 
4. Some comment edits