### PR TITLE
Feature/mpi-pio.output

### DIFF
--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -294,3 +294,47 @@ implicit none
  END TYPE LKFLX
 
 END MODULE dataTypes
+
+MODULE objTypes
+
+ USE nrtype,     only: i4b,dp,lgt
+ USE nrtype,     only: strLen   ! string length
+ USE public_var, only: realMissing
+ USE public_var, only: integerMissing
+
+ ! define derived type for model variables, including name, description, and units
+ type, public :: var_info_new
+   character(len=strLen)    :: varName  = 'empty'         ! variable name
+   character(len=strLen)    :: varDesc  = 'empty'         ! variable description
+   character(len=strLen)    :: varUnit  = 'empty'         ! variable units
+   integer(i4b)             :: varType  = integerMissing  ! variable type
+   integer(i4b),allocatable :: varDim(:)                  ! dimension ID associated with variable
+   logical(lgt)             :: varFile  = .true.          ! .true. if the variable should be read from a file
+ CONTAINS
+   procedure, pass :: init
+ end type var_info_new
+
+ CONTAINS
+
+  SUBROUTINE init(this, vName, vDesc, vUnit, vType, vDim, vFile)
+    implicit none
+    class(var_info_new)                 :: this
+    character(*),            intent(in) :: vName    ! variable name
+    character(*),            intent(in) :: vDesc    ! variable description
+    character(*),            intent(in) :: vUnit    ! variable units
+    integer(i4b),            intent(in) :: vType    ! variable type
+    integer(i4b),            intent(in) :: vDim(:)  ! dimension ID
+    logical(lgt),            intent(in) :: vFile    ! .true. if the variable should be read from a file
+    integer(i4b)                        :: n        ! size of dimension
+
+    n = size(vDim)
+    allocate(this%varDim(n))
+    this%varName      = vName
+    this%varDesc      = vDesc
+    this%varUnit      = vUnit
+    this%varType      = vType
+    this%varDim(1:n) = vDim(1:n)
+    this%varFile      = vFile
+  END SUBROUTINE init
+
+END MODULE objTypes

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -11,6 +11,7 @@ module globalData
   USE dataTypes, ONLY: struct_info   ! metadata type
   USE dataTypes, ONLY: dim_info      ! metadata type
   USE dataTypes, ONLY: var_info      ! metadata type
+  USE objTypes,  ONLY: var_info_new  ! metadata type
 
   ! parameter structures
   USE dataTypes, ONLY: RCHPRP        ! Reach parameters (properties)
@@ -130,11 +131,11 @@ module globalData
   type(var_info)                 , public :: meta_SEG    (nVarsSEG    ) ! stream segment properties
   type(var_info)                 , public :: meta_NTOPO  (nVarsNTOPO  ) ! network topology
   type(var_info)                 , public :: meta_PFAF   (nVarsPFAF   ) ! pfafstetter code
-  type(var_info)                 , public :: meta_rflx   (nVarsRFLX )   ! reach flux variables
-  type(var_info)                 , public :: meta_irf_bas(nVarsIRFbas ) ! basin IRF routing fluxes/states
-  type(var_info)                 , public :: meta_kwt    (nVarsKWT    ) ! KWT routing fluxes/states
-  type(var_info)                 , public :: meta_kwe    (nVarsKWE    ) ! KWE routing fluxes/states
-  type(var_info)                 , public :: meta_irf    (nVarsIRF    ) ! IRF routing fluxes/states
+  type(var_info_new)             , public :: meta_rflx   (nVarsRFLX   ) ! reach flux variables
+  type(var_info_new)             , public :: meta_irf_bas(nVarsIRFbas ) ! basin IRF routing fluxes/states
+  type(var_info_new)             , public :: meta_kwt    (nVarsKWT    ) ! KWT routing fluxes/states
+  type(var_info_new)             , public :: meta_irf    (nVarsIRF    ) ! IRF routing fluxes/states
+  type(var_info_new)             , public :: meta_kwe    (nVarsKWE    ) ! KWE routing fluxes/states
 
   ! ---------- shared data structures ----------------------------------------------------------------------
 

--- a/route/build/src/pio_utils.f90
+++ b/route/build/src/pio_utils.f90
@@ -11,9 +11,9 @@ module pio_utils
   public::pio_sys_init
   public::pio_decomp
   public::createFile
-  public::defDim
-  public::defVar
-  public::endDef
+  public::def_dim
+  public::def_var
+  public::end_def
   public::openFile
   public::closeFile
   public::write_netcdf             ! write non-distributed data
@@ -334,7 +334,7 @@ contains
   end subroutine closeFile
 
   !-----------------------------------------------------------------------
-  subroutine endDef(pioFileDesc, ierr, message)
+  subroutine end_def(pioFileDesc, ierr, message)
     ! !DESCRIPTION:
     ! end definition of netcdf file
     !
@@ -345,15 +345,15 @@ contains
     integer(i4b),      intent(out)   :: ierr         ! error status
     character(*),      intent(out)   :: message      ! error message
 
-    ierr=0; message='endDef/'
+    ierr=0; message='end_def/'
 
     ierr = pio_enddef(pioFileDesc)
     if(ierr/=pio_noerr)then; message=trim(message)//'Could not end define mode'; return; endif
 
-  end subroutine endDef
+  end subroutine end_def
 
   !-----------------------------------------------------------------------
-  subroutine defDim(pioFileDesc,   & ! input: file descriptor
+  subroutine def_dim(pioFileDesc,  & ! input: file descriptor
                     dimname,       & ! input: dimension name
                     dimlen,        & ! input: dimension size negative => record dimension
                     dimid)           ! output: dimension id
@@ -370,17 +370,17 @@ contains
       ierr = pio_def_dim(pioFileDesc, dimname, pio_unlimited, dimid)
     endif
 
-  end subroutine defDim
+  end subroutine def_dim
 
   !-----------------------------------------------------------------------
-  subroutine defVar(pioFileDesc,   & ! input: file descriptor
-                    vname,         & ! input: variable name
-                    pioDimId,      & ! input: dimension ID(s)
-                    ivtype,        & ! input: variable type. pio_int, pio_real, pio_double, pio_char
-                    ierr, message, & ! output: error code and message
-                    vdesc,         & ! input: optional. long_name
-                    vunit,         & ! input: optional. unit
-                    vcal)            ! input: optional. calendar type
+  subroutine def_var(pioFileDesc,   & ! input: file descriptor
+                     vname,         & ! input: variable name
+                     pioDimId,      & ! input: dimension ID(s)
+                     ivtype,        & ! input: variable type. pio_int, pio_real, pio_double, pio_char
+                     ierr, message, & ! output: error code and message
+                     vdesc,         & ! input: optional. long_name
+                     vunit,         & ! input: optional. unit
+                     vcal)            ! input: optional. calendar type
   implicit none
   ! input
   type(file_desc_t),intent(inout)         :: pioFileDesc            ! contains data identifying the file.
@@ -415,7 +415,7 @@ contains
   end if
 
 
-  end subroutine defVar
+  end subroutine def_var
 
   ! -----------------------------
   ! Writing routine

--- a/route/build/src/popMetadat.f90
+++ b/route/build/src/popMetadat.f90
@@ -1,5 +1,7 @@
 module popMetadat_module
 
+USE pio, ONLY: pio_real, pio_double, pio_int
+
 ! common variables
 USE public_var, ONLY: MAXQPAR
 USE public_var, ONLY: integerMissing
@@ -144,34 +146,32 @@ contains
  meta_PFAF  (ixPFAF%code             ) = var_info('code'           , 'pfafstetter code'                                   ,'-'    ,ixDims%seg   , .true.)
 
  ! ---------- populate segment fluxes/states metadata structures -----------------------------------------------------------------------------------------------------
- ! Reach Flux                                      varName             varDesc                                         unit,     varDim,              writeOut
- meta_rflx   (ixRFLX%basRunoff        ) = var_info('basRunoff'        , 'basin runoff'                                ,'m/s'    ,ixQdims%hru         ,.true.)
- meta_rflx   (ixRFLX%instRunoff       ) = var_info('instRunoff'       , 'instantaneous runoff in each reach'          ,'m3/s'   ,ixQdims%seg         ,.true.)
- meta_rflx   (ixRFLX%dlayRunoff       ) = var_info('dlayRunoff'       , 'delayed runoff in each reach'                ,'m3/s'   ,ixQdims%seg         ,.true.)
- meta_rflx   (ixRFLX%sumUpstreamRunoff) = var_info('sumUpstreamRunoff', 'sum of upstream runoff in each reach'        ,'m3/s'   ,ixQdims%seg         ,.true.)
- meta_rflx   (ixRFLX%KWTroutedRunoff  ) = var_info('KWTroutedRunoff'  , 'KWT routed runoff in each reach'             ,'m3/s'   ,ixQdims%seg         ,.true.)
- meta_rflx   (ixRFLX%KWEroutedRunoff  ) = var_info('KWEroutedRunoff'  , 'KWE routed runoff in each reach'             ,'m3/s'   ,ixQdims%seg         ,.true.)
- meta_rflx   (ixRFLX%IRFroutedRunoff  ) = var_info('IRFroutedRunoff'  , 'IRF routed runoff in each reach'             ,'m3/s'   ,ixQdims%seg         ,.true.)
+! Reach Flux                                   varName              varDesc                                 unit,   varType,  varDim,                     writeOut
+ call meta_rflx(ixRFLX%basRunoff        )%init('basRunoff'        , 'basin runoff'                        , 'm/s' , pio_real, [ixQdims%hru,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%instRunoff       )%init('instRunoff'       , 'instantaneous runoff in each reach'  , 'm3/s', pio_real, [ixQdims%seg,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%dlayRunoff       )%init('dlayRunoff'       , 'delayed runoff in each reach'        , 'm3/s', pio_real, [ixQdims%seg,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%sumUpstreamRunoff)%init('sumUpstreamRunoff', 'sum of upstream runoff in each reach', 'm3/s', pio_real, [ixQdims%seg,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%KWTroutedRunoff  )%init('KWTroutedRunoff'  , 'KWT routed runoff in each reach'     , 'm3/s', pio_real, [ixQdims%seg,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%KWEroutedRunoff  )%init('KWEroutedRunoff'  , 'KWE routed runoff in each reach'     , 'm3/s', pio_real, [ixQdims%seg,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%IRFroutedRunoff  )%init('IRFroutedRunoff'  , 'IRF routed runoff in each reach'     , 'm3/s', pio_real, [ixQdims%seg,ixQdims%time], .true.)
 
- ! Lagrangian Kinematic Wave                     varName             varDesc                                          unit,     varDim,              writeOut
- meta_kwt    (ixKWT%tentry          ) = var_info('tentry'          , 'time when a wave enters a segment'              ,'sec'    ,ixStateDims%wave    ,.true.)
- meta_kwt    (ixKWT%texit           ) = var_info('texit'           , 'time when a wave is expected to exit a segment' ,'sec'    ,ixStateDims%wave    ,.true.)
- meta_kwt    (ixKWT%qwave           ) = var_info('qwave'           , 'flow of a wave'                                 ,'m2/sec' ,ixStateDims%wave    ,.true.)
- meta_kwt    (ixKWT%qwave_mod       ) = var_info('qwave_mod'       , 'modified flow of a wave'                        ,'m2/sec' ,ixStateDims%wave    ,.true.)
- meta_kwt    (ixKWT%routed          ) = var_info('routed'          , 'routing flag'                                   ,'-'      ,ixStateDims%wave    ,.true.)
- meta_kwt    (ixKWT%q               ) = var_info('kwt_q'           , 'Kinematic wave routed flow'                     ,'m3/sec' ,ixStateDims%time    ,.true.)
+ ! Lagrangian Kinematic Wave         varName      varDesc                                           unit,   varType,    varDim,                                                              writeOut
+ call meta_kwt(ixKWT%tentry   )%init('tentry'   , 'time when a wave enters a segment'             , 's'   , pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens,ixStateDims%time], .true.)
+ call meta_kwt(ixKWT%texit    )%init('texit'    , 'time when a wave is expected to exit a segment', 's'   , pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens,ixStateDims%time], .true.)
+ call meta_kwt(ixKWT%qwave    )%init('qwave'    , 'flow of a wave'                                , 'm2/s', pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens,ixStateDims%time], .true.)
+ call meta_kwt(ixKWT%qwave_mod)%init('qwave_mod', 'modified flow of a wave'                       , 'm2/s', pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens,ixStateDims%time], .true.)
+ call meta_kwt(ixKWT%routed   )%init('routed'   , 'routing flag'                                  , '-'   , pio_int,    [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens,ixStateDims%time], .true.)
 
- ! Lagrangian Kinematic Wave                     varName             varDesc                                          unit,     varDim,              writeOut
- meta_kwe    (ixKWE%a               ) = var_info('flow_area'       , 'flow area'                                      ,'m2'     ,ixStateDims%fdmesh  ,.false.)
- meta_kwe    (ixKWE%q               ) = var_info('kwe_q'           , 'Kinematic wave routed flow'                     ,'m3/sec' ,ixStateDims%fdmesh  ,.false.)
+ ! Eulerian Kinematic Wave       varName      varDesc                       unit,   varType,    varDim,                                                              writeOut
+ call meta_kwe(ixKWE%a   )%init('flow_area', 'flow area'                  , 'm2'  , pio_double, [ixStateDims%seg,ixStateDims%fdmesh,ixStateDims%ens,ixStateDims%time], .true.)
+ call meta_kwe(ixKWE%q   )%init('kwe_q'    , 'Kinematic wave routed flow' , 'm2/s', pio_double, [ixStateDims%seg,ixStateDims%fdmesh,ixStateDims%ens,ixStateDims%time], .true.)
 
- ! Impulse Response Function                     varName             varDesc                                           unit,     varDim,              writeOut
- meta_irf    (ixIRF%qfuture         ) = var_info('irf_qfuture'     , 'future flow series'                             ,'m3/sec' ,ixStateDims%tdh_irf ,.true.)
- meta_irf    (ixIRF%q               ) = var_info('irf_q'           , 'irf routed flow'                                ,'m3/sec' ,ixStateDims%time    ,.true.)
+ ! Impulse Response Function       varName         varDesc              unit,   varType,    varDim,                                                                  writeOut
+ call meta_irf(ixIRF%qfuture)%init('irf_qfuture', 'future flow series', 'm3/s' ,pio_double, [ixStateDims%seg,ixStateDims%tdh_irf,ixStateDims%ens,ixStateDims%time] , .true.)
 
- ! Basin Impulse Response Function               varName             varDesc                                           unit,     varDim,              writeOut
- meta_irf_bas(ixIRFbas%qfuture      ) = var_info('qfuture'         , 'future flow series'                             ,'m3/sec' ,ixStateDims%tdh     ,.true.)
- meta_irf_bas(ixIRFbas%q            ) = var_info('basin_q'         , 'basin routed flow'                              ,'m3/sec' ,ixStateDims%time    ,.true.)
+ ! Basin Impulse Response Function        varName    varDesc               unit,   varType,    varDim,                                                             writeOut
+ call meta_irf_bas(ixIRFbas%qfuture)%init('qfuture', 'future flow series', 'm3/s' ,pio_double, [ixStateDims%seg,ixStateDims%tdh,ixStateDims%ens,ixStateDims%time], .true.)
+ call meta_irf_bas(ixIRFbas%q      )%init('basin_q', 'basin routed flow' , 'm3/s' ,pio_double, [ixStateDims%seg,ixStateDims%ens,ixStateDims%time]                , .true.)
 
  end subroutine popMetadat
 

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -28,6 +28,7 @@ contains
  USE globalData, ONLY: meta_SEG             ! stream segment properties
  USE globalData, ONLY: meta_NTOPO           ! network topology
  USE globalData, ONLY: meta_PFAF            ! pfafstetter code
+ USE globalData, ONLY: meta_rflx            ! river flux variables
 
  ! named variables in each structure
  USE var_lookup, ONLY: ixHRU                ! index of variables for data structure
@@ -35,6 +36,7 @@ contains
  USE var_lookup, ONLY: ixSEG                ! index of variables for data structure
  USE var_lookup, ONLY: ixNTOPO              ! index of variables for data structure
  USE var_lookup, ONLY: ixPFAF               ! index of variables for data structure
+ USE var_lookup, ONLY: ixRFLX               ! index of variables for data structure
 
  ! external subroutines
  USE ascii_util_module, ONLY:file_open        ! open file (performs a few checks as well)
@@ -75,6 +77,9 @@ contains
  close(iunit)
 
  ! loop through the non-comment lines in the input file, and extract the name and the information
+ if (masterproc) then
+   write(iulog,'(2a)') new_line('a'), '---- read control file --- '
+ end if
  do iLine=1,size(cLines)
 
    ! initialize io_error
@@ -90,7 +95,7 @@ contains
    cName = adjustl(cLines(iLine)(ibeg_name:iend_name))
    cData = adjustl(cLines(iLine)(iend_name+1:iend_data-1))
    if (masterproc) then
-    write(iulog,*) trim(cName), ' --> ', trim(cData)
+     write(iulog,'(x,a,a,a)') trim(cName), ' --> ', trim(cData)
    endif
 
    ! populate variables
@@ -146,13 +151,20 @@ contains
    case('<topoNetworkOption>');    read(cData,*,iostat=io_error) topoNetworkOption ! option for network topology calculations (0=read from file, 1=compute)
    case('<computeReachList>');     read(cData,*,iostat=io_error) computeReachList  ! option to compute list of upstream reaches (0=do not compute, 1=compute)
    ! TIME
-   case('<time_units>');           time_units = trim(cData)                        ! time units (seconds, hours, or days)
+   case('<time_units>');           time_units = trim(cData)                        ! time units. format should be <unit> since yyyy-mm-dd (hh:mm:ss). () can be omitted
    case('<calendar>');             calendar   = trim(cData)                        ! calendar name
    ! MISCELLANEOUS
    case('<desireId>'   );          read(cData,*,iostat=io_error) desireId          ! turn off checks or speficy reach ID if necessary to print on screen
    ! PFAFCODE
    case('<maxPfafLen>');           read(cData,*,iostat=io_error) maxPfafLen        ! maximum digit of pfafstetter code (default 32)
    case('<pfafMissing>');          pfafMissing = trim(cData)                       ! missing pfafcode (e.g., reach without any upstream area)
+   ! OUTPUT OPTIONS
+   case('<basRunoff>');            read(cData,*,iostat=io_error) meta_rflx(ixRFLX%basRunoff        )%varFile
+   case('<instRunoff>');           read(cData,*,iostat=io_error) meta_rflx(ixRFLX%instRunoff       )%varFile
+   case('<dlayRunoff>');           read(cData,*,iostat=io_error) meta_rflx(ixRFLX%dlayRunoff       )%varFile
+   case('<sumUpstreamRunoff>');    read(cData,*,iostat=io_error) meta_rflx(ixRFLX%sumUpstreamRunoff)%varFile
+   case('<KWTroutedRunoff>');      read(cData,*,iostat=io_error) meta_rflx(ixRFLX%KWTroutedRunoff  )%varFile
+   case('<IRFroutedRunoff>');      read(cData,*,iostat=io_error) meta_rflx(ixRFLX%IRFroutedRunoff  )%varFile
 
    ! VARIABLE NAMES for data (overwrite default name in popMeta.f90)
    ! HRU structure
@@ -199,7 +211,7 @@ contains
    ! if not in list then keep going
    case default
     message=trim(message)//'unexpected text in control file -- provided '//trim(cName)&
-                         //' (note strings in control file must match the variable names in var_lookup.f90)'
+                         //' (note strings in control file must match the variable names in public_var.f90)'
     err=20; return
 
   end select
@@ -212,7 +224,7 @@ contains
 
  end do  ! looping through lines in the control file
 
- ! control river network writing option
+ ! ---------- control river network writing option  ---------------------------------------------------------------------
  ! Case1- river network subset mode (idSegOut>0):  Write the network variables read from file over only upstream network specified idSegOut
  ! Case2- river network augment mode: Write full network variables over the entire network
  ! River network subset mode turnes off augmentation mode.
@@ -221,8 +233,12 @@ contains
    ntopAugmentMode = .false.
  endif
 
- ! ---------- unit conversion --------------------------------------------------------------------------------------------
+ ! ---------- runoff unit conversion --------------------------------------------------------------------------------------------
 
+ if (masterproc) then
+   write(iulog,'(2a)') new_line('a'), '---- runoff unit --- '
+   write(iulog,'(a)') '  runoff unit is provided as: '//trim(units_qsim)
+ end if
  ! find the position of the "/" character
  ipos = index(trim(units_qsim),'/')
  if(ipos==0)then
@@ -239,7 +255,7 @@ contains
   case('m');  length_conv = 1._dp
   case('mm'); length_conv = 1._dp/1000._dp
   case default
-   message=trim(message)//'expect the length units to be "m" or "mm" [units='//trim(cLength)//']'
+   message=trim(message)//'expect the length units of runoff to be "m" or "mm" [units='//trim(cLength)//']'
    err=81; return
  end select
 
@@ -249,7 +265,7 @@ contains
   case('h','hour');   time_conv = 1._dp/secprhour
   case('s','second'); time_conv = 1._dp
   case default
-   message=trim(message)//'cannot identify the time units [time units = '//trim(cTime)//']'
+   message=trim(message)//'expect the time units of to be "day"("d"), "hour"("h") or "second"("s") [time units = '//trim(cTime)//']'
    err=81; return
  end select
 

--- a/route/build/src/read_restart.f90
+++ b/route/build/src/read_restart.f90
@@ -1,4 +1,5 @@
 MODULE read_restart
+
 ! Moudle wide external modules
 USE nrtype, ONLY: i4b, dp, &
                   strLen
@@ -189,8 +190,6 @@ CONTAINS
 
   do iVar=1,nVarsIRF
 
-   if (iVar==ixIRF%q) cycle
-
    select case(iVar)
     case(ixIRF%qfuture); allocate(state(impulseResponseFunc)%var(iVar)%array_3d_dp(nSeg, ntdh_irf, nens), stat=ierr)
     case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
@@ -203,8 +202,6 @@ CONTAINS
   if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
   do iVar=1,nVarsIRF
-
-   if (iVar==ixIRF%q) cycle
 
    select case(iVar)
     case(ixIRF%qfuture); call get_nc(fname, meta_irf(iVar)%varName, state(impulseResponseFunc)%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,ntdh_irf,nens/), ierr, cmessage)
@@ -223,8 +220,6 @@ CONTAINS
     if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
     do iVar=1,nVarsIRF
-
-     if (iVar==ixIRF%q) cycle ! not writing out IRF routed flow
 
      select case(iVar)
       case(ixIRF%qfuture); RCHFLX(iens,jSeg)%QFUTURE_IRF = state(impulseResponseFunc)%var(iVar)%array_3d_dp(iSeg,1:numQF(iens,iSeg),iens)
@@ -267,8 +262,6 @@ CONTAINS
 
   do iVar=1,nVarsKWT
 
-    if (iVar==ixKWT%q) cycle  ! not writing out river flow in state file
-
     select case(iVar)
      case(ixKWT%routed); allocate(state(kinematicWave)%var(iVar)%array_3d_dp(nSeg, nwave, nens), stat=ierr)
      case(ixKWT%tentry, ixKWT%texit, ixKWT%qwave, ixKWT%qwave_mod)
@@ -282,8 +275,6 @@ CONTAINS
   if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
   do iVar=1,nVarsKWT
-
-    if (iVar==ixKWT%q) cycle  ! not writing out river flow in state file
 
     select case(iVar)
      case(ixKWT%routed)
@@ -303,8 +294,6 @@ CONTAINS
     allocate(RCHSTA(iens,jSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1), stat=ierr)
 
     do iVar=1,nVarsKWT
-
-     if (iVar==ixKWT%q) cycle ! not writing out KWT routed flow
 
      select case(iVar)
       case(ixKWT%tentry);    RCHSTA(iens,jSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%TI = state(kinematicWave)%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)

--- a/route/build/src/var_lookup.f90
+++ b/route/build/src/var_lookup.f90
@@ -150,7 +150,6 @@ MODULE var_lookup
   integer(i4b)     :: qwave          = integerMissing  ! wave flow
   integer(i4b)     :: qwave_mod      = integerMissing  ! wave flow after merged
   integer(i4b)     :: routed         = integerMissing  ! Routed out of a segment or not
-  integer(i4b)     :: q              = integerMissing  ! final discharge
  endtype iLook_KWT
  ! KWE state/fluxes
  type, public  ::  iLook_KWE
@@ -160,7 +159,6 @@ MODULE var_lookup
  !IRF state/fluxes
  type, public  ::  iLook_IRF
   integer(i4b)     :: qfuture        = integerMissing  ! future routed flow
-  integer(i4b)     :: q              = integerMissing  ! final discharge
  endtype iLook_IRF
  ! ***********************************************************************************************************
  ! ** define data vectors
@@ -175,9 +173,9 @@ MODULE var_lookup
  type(iLook_NTOPO)    ,public,parameter :: ixNTOPO     = iLook_NTOPO    (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17)
  type(iLook_PFAF)     ,public,parameter :: ixPFAF      = iLook_PFAF     (1)
  type(iLook_rflx)     ,public,parameter :: ixRFLX      = iLook_rflx     (1,2,3,4,5,6,7)
- type(iLook_KWT)      ,public,parameter :: ixKWT       = iLook_KWT      (1,2,3,4,5,6)
+ type(iLook_KWT)      ,public,parameter :: ixKWT       = iLook_KWT      (1,2,3,4,5)
  type(iLook_KWE)      ,public,parameter :: ixKWE       = iLook_KWE      (1,2)
- type(iLook_IRF)      ,public,parameter :: ixIRF       = iLook_IRF      (1,2)
+ type(iLook_IRF)      ,public,parameter :: ixIRF       = iLook_IRF      (1)
  type(iLook_IRFbas  ) ,public,parameter :: ixIRFbas    = iLook_IRFbas   (1,2)
  ! ***********************************************************************************************************
  ! ** define size of data vectors

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -2,6 +2,7 @@ MODULE write_simoutput_pio
 
 ! Moudle wide shared data
 USE nrtype
+USE var_lookup,        ONLY: ixRFLX, nVarsRFLX
 USE dataTypes,         ONLY: STRFLX            ! fluxes in each reach
 USE public_var,        ONLY: iulog             ! i/o logical unit number
 USE public_var,        ONLY: integerMissing
@@ -12,6 +13,7 @@ USE public_var,        ONLY: kinematicWave       ! Lagrangian kinematic wave
 USE public_var,        ONLY: kinematicWaveEuler  ! Eulerian kinematic wave
 USE public_var,        ONLY: impulseResponseFunc ! impulse response function
 USE public_var,        ONLY: allRoutingMethods   ! all routing methods
+USE globalData,        ONLY: meta_rflx
 USE globalData,        ONLY: pid, nNodes
 USE globalData,        ONLY: masterproc
 USE globalData,        ONLY: mpicom_route
@@ -50,7 +52,7 @@ contains
  ! *********************************************************************
  subroutine output(ierr, message)
 
-  !Dependent modules
+  ! global data required only this routine
   USE globalData, ONLY: RCHFLX_main         ! mainstem Reach fluxes (ensembles, space [reaches])
   USE globalData, ONLY: RCHFLX_trib         ! tributary Reach fluxes (ensembles, space [reaches])
   USE globalData, ONLY: basinRunoff_main    ! mainstem only HRU runoff
@@ -115,41 +117,45 @@ contains
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
   ! write the basin runoff to the netcdf file
-  call write_pnetcdf_recdim(pioFileDesc, 'basRunoff',basinRunoff, iodesc_hru_ro, jTime, ierr, cmessage)
-  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-  if (doesBasinRoute == 1) then
-   ! write instataneous local runoff in each stream segment (m3/s)
-   call write_pnetcdf_recdim(pioFileDesc, 'instRunoff', RCHFLX_local(:)%BASIN_QI, iodesc_rch_flx, jTime, ierr, cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+  if (meta_rflx(ixRFLX%basRunoff)%varFile) then
+    call write_pnetcdf_recdim(pioFileDesc, 'basRunoff',basinRunoff, iodesc_hru_ro, jTime, ierr, cmessage)
+    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   endif
 
-  ! write routed local runoff in each stream segment (m3/s)
-  call write_pnetcdf_recdim(pioFileDesc, 'dlayRunoff', RCHFLX_local(:)%BASIN_QR(1), iodesc_rch_flx, jTime, ierr, cmessage)
-  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-  ! write accumulated runoff (m3/s)
-  if (doesAccumRunoff == 1) then
-   call write_pnetcdf_recdim(pioFileDesc, 'sumUpstreamRunoff', RCHFLX_local(:)%UPSTREAM_QI, iodesc_rch_flx, jTime, ierr, cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+  if (meta_rflx(ixRFLX%instRunoff)%varFile) then
+    ! write instataneous local runoff in each stream segment (m3/s)
+    call write_pnetcdf_recdim(pioFileDesc, 'instRunoff', RCHFLX_local(:)%BASIN_QI, iodesc_rch_flx, jTime, ierr, cmessage)
+    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   endif
 
-  if (routOpt==allRoutingMethods .or. routOpt==kinematicWave) then
-   ! write routed runoff (m3/s)
-   call write_pnetcdf_recdim(pioFileDesc, 'KWTroutedRunoff', RCHFLX_local(:)%REACH_Q, iodesc_rch_flx, jTime, ierr, cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+  if (meta_rflx(ixRFLX%dlayRunoff)%varFile) then
+    ! write routed local runoff in each stream segment (m3/s)
+    call write_pnetcdf_recdim(pioFileDesc, 'dlayRunoff', RCHFLX_local(:)%BASIN_QR(1), iodesc_rch_flx, jTime, ierr, cmessage)
+    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   endif
 
-  if (routOpt==kinematicWaveEuler) then
-   ! write routed runoff (m3/s)
-   call write_pnetcdf_recdim(pioFileDesc, 'KWEroutedRunoff', RCHFLX_local(:)%REACH_Q, iodesc_rch_flx, jTime, ierr, cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+  if (meta_rflx(ixRFLX%sumUpstreamRunoff)%varFile) then
+    ! write accumulated runoff (m3/s)
+    call write_pnetcdf_recdim(pioFileDesc, 'sumUpstreamRunoff', RCHFLX_local(:)%UPSTREAM_QI, iodesc_rch_flx, jTime, ierr, cmessage)
+    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   endif
 
-  if (routOpt==allRoutingMethods .or. routOpt==impulseResponseFunc) then
-   ! write routed runoff (m3/s)
-   call write_pnetcdf_recdim(pioFileDesc, 'IRFroutedRunoff', RCHFLX_local(:)%REACH_Q_IRF, iodesc_rch_flx, jTime, ierr, cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+  if (meta_rflx(ixRFLX%KWTroutedRunoff)%varFile) then
+    ! write routed runoff (m3/s)
+    call write_pnetcdf_recdim(pioFileDesc, 'KWTroutedRunoff', RCHFLX_local(:)%REACH_Q, iodesc_rch_flx, jTime, ierr, cmessage)
+    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+  endif
+
+  if (meta_rflx(ixRFLX%KWEroutedRunoff)%varFile) then
+    ! write routed runoff (m3/s)
+    call write_pnetcdf_recdim(pioFileDesc, 'KWEroutedRunoff', RCHFLX_local(:)%REACH_Q, iodesc_rch_flx, jTime, ierr, cmessage)
+    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+  endif
+
+  if (meta_rflx(ixRFLX%IRFroutedRunoff)%varFile) then
+     ! write routed runoff (m3/s)
+     call write_pnetcdf_recdim(pioFileDesc, 'IRFroutedRunoff', RCHFLX_local(:)%REACH_Q_IRF, iodesc_rch_flx, jTime, ierr, cmessage)
+     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   endif
 
  end subroutine output
@@ -170,7 +176,7 @@ contains
  USE globalData, ONLY: basinID,reachID   ! HRU and reach ID in network
  USE globalData, ONLY: modJulday         ! julian day: at model time step
  USE globalData, ONLY: modTime           ! previous and current model time
- USE globalData, ONLY: nHRU, nRch        ! number of ensembles, HRUs and river reaches
+ USE globalData, ONLY: nEns, nHRU, nRch  ! number of ensembles, HRUs and river reaches
  USE globalData, ONLY: isFileOpen        ! file open/close status
  ! subroutines
  USE time_utils_module, ONLy: compCalday        ! compute calendar day
@@ -231,6 +237,9 @@ contains
 
    ! define output file
    call defineFile(trim(fileout),                         &  ! input: file name
+                   nEns,                                  &  ! input: number of ensembles
+                   nHRU,                                  &  ! input: number of HRUs
+                   nRch,                                  &  ! input: number of stream segments
                    time_units,                            &  ! input: time units
                    calendar,                              &  ! input: calendar
                    ierr,cmessage)                            ! output: error control
@@ -275,65 +284,68 @@ contains
  ! private subroutine: define routing output NetCDF file
  ! *********************************************************************
  SUBROUTINE defineFile(fname,           &  ! input: filename
+                       nEns_in,         &  ! input: number of ensembles
+                       nHRU_in,         &  ! input: number of HRUs
+                       nRch_in,         &  ! input: number of stream segments
                        units_time,      &  ! input: time units
                        calendar,        &  ! input: calendar
                        ierr, message)      ! output: error control
  !Dependent modules
  USE var_lookup, ONLY: ixQdims, nQdims
- USE var_lookup, ONLY: ixRFLX, nVarsRFLX
- USE globalData, ONLY: meta_rflx
  USE globalData, ONLY: meta_qDims
  USE globalData, ONLY: rch_per_proc             ! number of reaches assigned to each proc (size = num of procs+1)
  USE globalData, ONLY: hru_per_proc             ! number of hrus assigned to each proc (size = num of procs+1)
- USE globalData, ONLY: nEns, nHRU, nRch         ! number of ensembles, HRUs and river reaches
 
  implicit none
  ! input variables
- character(*), intent(in)    :: fname             ! filename
- character(*), intent(in)    :: units_time        ! time units
- character(*), intent(in)    :: calendar          ! calendar
+ character(*), intent(in)          :: fname             ! filename
+ integer(i4b), intent(in)          :: nEns_in           ! number of ensembles
+ integer(i4b), intent(in)          :: nHRU_in           ! number of HRUs
+ integer(i4b), intent(in)          :: nRch_in           ! number of stream segments
+ character(*), intent(in)          :: units_time        ! time units
+ character(*), intent(in)          :: calendar          ! calendar
  ! output variables
- integer(i4b), intent(out)   :: ierr              ! error code
- character(*), intent(out)   :: message           ! error message
+ integer(i4b), intent(out)         :: ierr              ! error code
+ character(*), intent(out)         :: message           ! error message
  ! local variables
- character(len=strLen)       :: cmessage          ! error message of downwind routine
- integer(i4b)                :: jDim,iVar         ! dimension, and variable index
- integer(i4b)                :: ix1, ix2          ! frst and last indices of global array for local array chunk
- integer(i4b)                :: ixRch(nRch)        !
- integer(i4b)                :: ixHRU(nHRU)        !
- integer(i4b)                :: ixDim
- integer(i4b)                :: dim_array(2)
+ integer(i4b),allocatable          :: dim_array(:)      ! dimension
+ integer(i4b)                      :: jDim,iVar         ! dimension, and variable index
+ integer(i4b)                      :: nDims             ! number of dimension
+ integer(i4b)                      :: ix1, ix2          ! frst and last indices of global array for local array chunk
+ integer(i4b)                      :: ixRch(nRch_in)    !
+ integer(i4b)                      :: ixHRU(nHRU_in)    !
+ integer(i4b)                      :: ixDim             !
+ character(len=strLen)             :: cmessage          ! error message of downwind routine
 
  ! initialize error control
  ierr=0; message='defineFile/'
 
  ! populate q dimension meta (not sure if this should be done here...)
- meta_qDims(ixQdims%seg)%dimLength = nRch
- meta_qDims(ixQdims%hru)%dimLength = nHRU
- meta_qDims(ixQdims%ens)%dimLength = nEns
+ meta_qDims(ixQdims%seg)%dimLength = nRch_in
+ meta_qDims(ixQdims%hru)%dimLength = nHRU_in
+ meta_qDims(ixQdims%ens)%dimLength = nEns_in
 
  ! Modify write option
  ! This is temporary
  if (routOpt==kinematicWave) then
-  meta_rflx(ixRFLX%IRFroutedRunoff)%varFile = .false.
-  meta_rflx(ixRFLX%KWEroutedRunoff)%varFile = .false.
+   meta_rflx(ixRFLX%IRFroutedRunoff)%varFile = .false.
+   meta_rflx(ixRFLX%KWEroutedRunoff)%varFile = .false.
+ elseif (routOpt==kinematicWaveEuler) then
+   meta_rflx(ixRFLX%IRFroutedRunoff)%varFile = .false.
+   meta_rflx(ixRFLX%KWTroutedRunoff)%varFile = .false.
+ elseif (routOpt==impulseResponseFunc) then
+   meta_rflx(ixRFLX%KWTroutedRunoff)%varFile = .false.
+   meta_rflx(ixRFLX%KWEroutedRunoff)%varFile = .false.
+ elseif (routOpt==allRoutingMethods) then
+   meta_rflx(ixRFLX%KWEroutedRunoff)%varFile = .false.
  end if
- if (routOpt==kinematicWaveEuler) then
-  meta_rflx(ixRFLX%IRFroutedRunoff)%varFile = .false.
-  meta_rflx(ixRFLX%KWTroutedRunoff)%varFile = .false.
- end if
- if (routOpt==impulseResponseFunc) then
-  meta_rflx(ixRFLX%KWTroutedRunoff)%varFile = .false.
-  meta_rflx(ixRFLX%KWEroutedRunoff)%varFile = .false.
- end if
- if (routOpt==allRoutingMethods) then
-  meta_rflx(ixRFLX%KWEroutedRunoff)%varFile = .false.
- end if
+ ! runoff accumulation option
  if (doesAccumRunoff==0) then
-  meta_rflx(ixRFLX%sumUpstreamRunoff)%varFile = .false.
+   meta_rflx(ixRFLX%sumUpstreamRunoff)%varFile = .false.
  end if
+ ! basin runoff routing option
  if (doesBasinRoute==0) then
-  meta_rflx(ixRFLX%instRunoff)%varFile = .false.
+   meta_rflx(ixRFLX%instRunoff)%varFile = .false.
  end if
 
  ! pio initialization
@@ -350,11 +362,11 @@ contains
    ix1 = sum(rch_per_proc(-1:pid-1))+1
  endif
  ix2 = sum(rch_per_proc(-1:pid))
- ixRch = arth(1,1,nRch)
+ ixRch = arth(1,1,nRch_in)
 
  call pio_decomp(pioSystem,              & ! input: pio system descriptor
                  ncd_double,             & ! input: data type (pio_int, pio_real, pio_double, pio_char)
-                 [nRch],                 & ! input: dimension length == global array size
+                 [nRch_in],              & ! input: dimension length == global array size
                  ixRch(ix1:ix2),         & ! input:
                  iodesc_rch_flx)
 
@@ -365,28 +377,30 @@ contains
    ix1 = sum(hru_per_proc(-1:pid-1))+1
  endif
  ix2 = sum(hru_per_proc(-1:pid))
- ixHRU = arth(1,1,nHRU)
+ ixHRU = arth(1,1,nHRU_in)
 
  call pio_decomp(pioSystem,     & ! input: pio system descriptor
                  ncd_double,    & ! input: data type (pio_int, pio_real, pio_double, pio_char)
-                 [nHRU],        & ! input: dimension length == global array size
+                 [nHRU_in],     & ! input: dimension length == global array size
                  ixHRU(ix1:ix2),& ! input:
                  iodesc_hru_ro)
 
+ ! --------------------
+ ! define file
+ ! --------------------
  call createFile(pioSystem, trim(fname), pio_typename, pio_netcdf_format, pioFileDesc, ierr, cmessage)
- if(ierr/=0)then; message=trim(cmessage)//'cannot create netCDF'; return; endif
+ if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  do jDim =1,nQdims
    if (jDim ==ixQdims%time) then ! time dimension (unlimited)
-    call defdim(pioFileDesc, trim(meta_qDims(jDim)%dimName), recordDim, meta_qDims(jDim)%dimId)
+    call def_dim(pioFileDesc, trim(meta_qDims(jDim)%dimName), recordDim, meta_qDims(jDim)%dimId)
    else
-    call defdim(pioFileDesc, trim(meta_qDims(jDim)%dimName), meta_qDims(jDim)%dimLength, meta_qDims(jDim)%dimId)
+    call def_dim(pioFileDesc, trim(meta_qDims(jDim)%dimName), meta_qDims(jDim)%dimLength, meta_qDims(jDim)%dimId)
    endif
-  if(ierr/=0)then; message=trim(message)//'cannot define dimension'; return; endif
  end do
 
  ! define coordinate variable for time
- call defVar(pioFileDesc,                                 &                                        ! pio file descriptor
+ call def_var(pioFileDesc,                                &                                        ! pio file descriptor
              trim(meta_qDims(ixQdims%time)%dimName),      &                                        ! variable name
              [meta_qDims(ixQdims%time)%dimId], ncd_float, &                                        ! dimension array and type
              ierr, cmessage,                              &                                        ! error handle
@@ -394,9 +408,10 @@ contains
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  ! define hru ID and reach ID variables
- call defvar(pioFileDesc, 'basinID', [meta_qDims(ixQdims%hru)%dimId], ncd_int, ierr, cmessage, vdesc='basin ID', vunit='-')
+ call def_var(pioFileDesc, 'basinID', [meta_qDims(ixQdims%hru)%dimId], ncd_int, ierr, cmessage, vdesc='basin ID', vunit='-')
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
- call defvar(pioFileDesc, 'reachID', [meta_qDims(ixQdims%seg)%dimId], ncd_int, ierr, cmessage, vdesc='reach ID', vunit='-')
+
+ call def_var(pioFileDesc, 'reachID', [meta_qDims(ixQdims%seg)%dimId], ncd_int, ierr, cmessage, vdesc='reach ID', vunit='-')
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  ! define flux variables
@@ -405,11 +420,17 @@ contains
   if (.not.meta_rflx(iVar)%varFile) cycle
 
   ! define dimension ID array
-  ixDim = meta_rflx(iVar)%varType
-  dim_array = [meta_qDims(ixDim)%dimId, meta_qDims(ixQdims%time)%dimId]
+  nDims = size(meta_rflx(iVar)%varDim)
+  if (allocated(dim_array)) then
+    deallocate(dim_array)
+  endif
+  allocate(dim_array(nDims))
+  do ixDim = 1, nDims
+    dim_array(ixDim) = meta_qDims(meta_rflx(iVar)%varDim(ixDim))%dimId
+  end do
 
   ! define variable
-  call defvar(pioFileDesc,             &                 ! pio file descriptor
+  call def_var(pioFileDesc,            &                 ! pio file descriptor
               meta_rflx(iVar)%varName, &                 ! variable name
               dim_array, ncd_float,    &                 ! dimension array and type
               ierr, cmessage,          &                 ! error handling
@@ -419,7 +440,7 @@ contains
  end do
 
  ! end definitions
- call endDef(pioFileDesc, ierr, cmessage)
+ call end_def(pioFileDesc, ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  END SUBROUTINE defineFile


### PR DESCRIPTION
1. Modify (cleanup) river flow and restart output routine. 
  1.1. Create and use new data type that allow to include dimension-name array in output flow/restart meta data.
  1.2. Allow user to control river flow output options (read_control.f90)
  1.3. Removed unnecessary restart variables (IRF%q)
2. Some minor subroutine name changes (pio_utils.f90)