### PR TITLE
Feature/mpi-pio.time.4

### DIFF
--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -37,21 +37,21 @@ module globalData
   ! time data structure
   USE dataTypes, ONLY: time         ! time data
 
-  ! data size
-  USE var_lookup, ONLY: nStructures   ! number of variables for data structure
-  USE var_lookup, ONLY: nDimensions   ! number of variables for data structure
-  USE var_lookup, ONLY: nStateDims    ! number of variables for data structure
-  USE var_lookup, ONLY: nQdims        ! number of variables for data structure
-  USE var_lookup, ONLY: nVarsHRU      ! number of variables for data structure
-  USE var_lookup, ONLY: nVarsHRU2SEG  ! number of variables for data structure
-  USE var_lookup, ONLY: nVarsSEG      ! number of variables for data structure
-  USE var_lookup, ONLY: nVarsNTOPO    ! number of variables for data structure
-  USE var_lookup, ONLY: nVarsPFAF     ! number of variables for data structure
-  USE var_lookup, ONLY: nVarsRFLX     ! number of variables for data structure
-  USE var_lookup, ONLY: nVarsIRFbas   ! number of variables for data structure
-  USE var_lookup, ONLY: nVarsIRF      ! number of variables for data structure
-  USE var_lookup, ONLY: nVarsKWT      ! number of variables for data structure
-  USE var_lookup, ONLY: nVarsKWE      ! number of variables for data structure
+  ! number of variables for data structure
+  USE var_lookup, ONLY: nStructures
+  USE var_lookup, ONLY: nDimensions
+  USE var_lookup, ONLY: nStateDims
+  USE var_lookup, ONLY: nQdims
+  USE var_lookup, ONLY: nVarsHRU
+  USE var_lookup, ONLY: nVarsHRU2SEG
+  USE var_lookup, ONLY: nVarsSEG
+  USE var_lookup, ONLY: nVarsNTOPO
+  USE var_lookup, ONLY: nVarsPFAF
+  USE var_lookup, ONLY: nVarsRFLX
+  USE var_lookup, ONLY: nVarsIRFbas
+  USE var_lookup, ONLY: nVarsIRF
+  USE var_lookup, ONLY: nVarsKWT
+  USE var_lookup, ONLY: nVarsKWE
 
   implicit none
 
@@ -67,13 +67,15 @@ module globalData
   integer(i4b)    , allocatable  , public :: basinID(:)           ! HRU id
   integer(i4b)    , allocatable  , public :: reachID(:)           ! reach id
 
-  ! ---------- Data/Time data  -------------------------------------------------------------------------
+  ! ---------- Date/Time data  -------------------------------------------------------------------------
 
   integer(i4b)                   , public :: iTime                ! time index at simulation time step
   real(dp)                       , public :: startJulday          ! julian day: start of routing simulation
   real(dp)                       , public :: endJulday            ! julian day: end of routing simulation
   real(dp)                       , public :: refJulday            ! julian day: reference
   real(dp)                       , public :: modJulday            ! julian day: simulation time step
+  real(dp)                       , public :: restartJulday        ! julian day: restart drop off
+  real(dp)        , allocatable  , public :: roJulday(:)          ! julian day: runoff input time
   real(dp)        , allocatable  , public :: timeVar(:)           ! time variables (unit given by runoff data)
   real(dp)                       , public :: TSEC(0:1)            ! begning and end of time step (sec)
   type(time)                     , public :: modTime(0:1)         ! previous and current model time (yyyy:mm:dd:hh:mm:ss)
@@ -103,7 +105,6 @@ module globalData
 
   ! ---------- conversion factors -------------------------------------------------------------------
 
-  real(dp)                       , public :: convTime2Days              ! conversion factor to convert time to units of days
   real(dp)                       , public :: time_conv                  ! time conversion factor -- used to convert to mm/s
   real(dp)                       , public :: length_conv                ! length conversion factor -- used to convert to mm/s
 

--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -16,6 +16,7 @@ USE public_var, ONLY: iulog              ! i/o logical unit number
 USE public_var, ONLY: verySmall
 USE public_var, ONLY: integerMissing
 USE public_var, ONLY: realMissing
+USE public_var, ONLY: charMissing
 
 implicit none
 
@@ -268,13 +269,10 @@ CONTAINS
  ! *********************************************************************
  SUBROUTINE update_time(finished, ierr, message)
 
-  ! Shared data
-  USE public_var, ONLY: dt
+  USE public_var, ONLY: dt            ! time step [sec]
   USE globalData, ONLY: TSEC          ! beginning/ending of simulation time step [sec]
-  USE globalData, ONLY: timeVar       ! time variables (unit given by runoff data)
   USE globalData, ONLY: iTime         ! time index at simulation time step
-  USE globalData, ONLY: convTime2Days ! conversion multipliers for time unit of runoff input to day
-  USE globalData, ONLY: refJulday     ! julian day: reference
+  USE globalData, ONLY: roJulday      ! julian day: runoff input time
   USE globalData, ONLY: modJulday     ! julian day: at model time step
   USE globalData, ONLY: endJulday     ! julian day: at end of simulation
   ! external routine
@@ -289,20 +287,20 @@ CONTAINS
    ! initialize error control
    ierr=0; message='update_time/'
 
-   ! update model time step bound
-   TSEC(0) = TSEC(0) + dt
-   TSEC(1) = TSEC(0) + dt
-
    if (abs(modJulday-endJulday)<verySmall) then
      call close_output_nc()
      finished=.true.;return
    endif
 
+   ! update model time step bound
+   TSEC(0) = TSEC(0) + dt
+   TSEC(1) = TSEC(0) + dt
+
    ! update time index
    iTime=iTime+1
 
    ! update the julian day of the model simulation
-   modJulday = refJulday + timeVar(iTime)/convTime2Days
+   modJulday = roJulday(iTime)
 
  END SUBROUTINE update_time
 
@@ -315,13 +313,11 @@ CONTAINS
   ! external routines
   USE read_restart,      ONLY: read_state_nc     ! read netcdf state output file
   USE mpi_routine,       ONLY: mpi_restart
-  ! global data
+  ! shared data
   USE public_var, ONLY: dt                ! simulation time step (seconds)
-  USE public_var, ONLY: isRestart         ! restart option: True-> model run with restart, F -> model run with empty channels
   USE public_var, ONLY: routOpt           ! routing scheme options  0-> both, 1->IRF, 2->KWT, otherwise error
-  USE public_var, ONLY: fname_state_in    ! name of state input file
   USE public_var, ONLY: output_dir        ! directory containing output data
-  USE public_var, ONLY: routOpt           ! routing scheme options
+  USE public_var, ONLY: fname_state_in    ! name of state input file
   USE public_var, ONLY: kinematicWaveEuler!
   USE globalData, ONLY: masterproc        ! root proc logical
   USE globalData, ONLY: nRch_mainstem     ! number of mainstem reaches
@@ -352,13 +348,14 @@ CONTAINS
   iens = 1_i4b
 
   ! read restart file and initialize states
-  if (isRestart) then
+  if (trim(fname_state_in)/=charMissing) then
 
    if (masterproc) then
     call read_state_nc(trim(output_dir)//trim(fname_state_in), routOpt, T0, T1, ierr, cmessage)
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-    TSEC(0)=T0; TSEC(1)=T1
+    ! time bound [sec] is at previous time step, so need to add dt for curent time step
+    TSEC(0)=T0+dt; TSEC(1)=T1+dt
 
    end if
 

--- a/route/build/src/mpi_process.f90
+++ b/route/build/src/mpi_process.f90
@@ -1946,7 +1946,6 @@ contains
  ! *********************************************************************
  ! send all the necessary public/global variables neccesary in task
  subroutine pass_global_data(comm, ierr,message)   ! output: error control
-  USE globalData, ONLY: convTime2Days     ! conversion multipliers for time unit of runoff input to day
   USE globalData, ONLY: nRch,nHRU         ! number of reaches and hrus in whole network
   USE globalData, ONLY: timeVar           ! time variable
   USE globalData, ONLY: iTime             ! time index
@@ -1954,6 +1953,8 @@ contains
   USE globalData, ONLY: startJulday       ! julian day: start
   USE globalData, ONLY: endJulday         ! julian day: end
   USE globalData, ONLY: modJulday         ! julian day: at simulation time step
+  USE globalData, ONLY: restartJulday     ! julian day: at restart
+  USE globalData, ONLY: roJulday          ! julian day: runoff input time
   USE globalData, ONLY: reachID
   USE globalData, ONLY: basinID
   implicit none
@@ -1973,12 +1974,13 @@ contains
   call MPI_BCAST(nHRU,        1,     MPI_INTEGER,          root, comm, ierr)
   call MPI_BCAST(calendar,  strLen,  MPI_CHARACTER,        root, comm, ierr)
   call MPI_BCAST(time_units,strLen,  MPI_CHARACTER,        root, comm, ierr)
-  call MPI_BCAST(convTime2Days,1,    MPI_DOUBLE_PRECISION, root, comm, ierr)
-  call MPI_BCAST(refJulday,   1,     MPI_DOUBLE_PRECISION, root, comm, ierr)
-  call MPI_BCAST(startJulday, 1,     MPI_DOUBLE_PRECISION, root, comm, ierr)
-  call MPI_BCAST(endJulday,   1,     MPI_DOUBLE_PRECISION, root, comm, ierr)
-  call MPI_BCAST(modJulday,   1,     MPI_DOUBLE_PRECISION, root, comm, ierr)
+  call MPI_BCAST(refJulday,     1,   MPI_DOUBLE_PRECISION, root, comm, ierr)
+  call MPI_BCAST(startJulday,   1,   MPI_DOUBLE_PRECISION, root, comm, ierr)
+  call MPI_BCAST(endJulday,     1,   MPI_DOUBLE_PRECISION, root, comm, ierr)
+  call MPI_BCAST(modJulday,     1,   MPI_DOUBLE_PRECISION, root, comm, ierr)
+  call MPI_BCAST(restartJulday, 1,   MPI_DOUBLE_PRECISION, root, comm, ierr)
 
+  call shr_mpi_bcast(roJulday,ierr, message)
   call shr_mpi_bcast(timeVar,ierr, message)
   call shr_mpi_bcast(reachID,ierr, message)
   call shr_mpi_bcast(basinID,ierr, message)

--- a/route/build/src/network_topo.f90
+++ b/route/build/src/network_topo.f90
@@ -373,7 +373,6 @@ contains
  integer(i4b)                    :: rankDownSeg(nUp)    ! rank index of each downstream stream segment
  logical(lgt),parameter          :: checkLink=.false.   ! flag to check the links
  logical(lgt),parameter          :: checkMap=.true.     ! flag to check the mapping
- integer(i4b),parameter          :: nProgress=100000    ! print every nProgress step
 
  ! initialize error control
  ierr=0; message='downReachIndex/'
@@ -391,9 +390,6 @@ contains
  iSeg=1  ! second counter
  ! loop through the upstream elements
  do iUp=1,nUp
-
-  ! print progress
-  if(mod(iUp,nProgress)==0) write(iulog,*) 'Getting downstream link for reach: ', iUp, nUp
 
   ! get Ids for the up2seg mapping vector
   rankDownId = downId( rankDownSeg(iUp) )
@@ -496,10 +492,6 @@ contains
  DO  ! do until all reaches are assigned
   NASSIGN = 0
   DO IRCH=1,NRCH
-   ! print progress
-   if(jCount>0)then
-    if(mod(jCount,100000)==0) write(iulog,*) 'Getting order for reach: ', count(RCHFLAG), nRch
-   endif
    ! check if the reach is assigned yet
    IF(RCHFLAG(IRCH)) THEN
     NASSIGN = NASSIGN + 1
@@ -663,7 +655,6 @@ contains
  integer(i4b)                                   :: nUpstream       ! total number of upstream reaches
  integer(i4b)                                   :: iUps            ! index of upstream reaches
  integer(i4b)                                   :: iPos            ! position in vector
- integer(i4b),parameter                         :: nProgress=100000! print every nProgress step
  ! ----------------------------------------------------------------------------------------
  message='reach_list/'
 
@@ -687,9 +678,6 @@ contains
  do kRch=1,nRch
 
   ! ---------- identify reach in the ordered vector ----------------------------------------
-
-  ! print progress
-  if(mod(kRch,nProgress)==0) write(iulog,*) 'Getting list of all upstream reaches: kRch, nRch = ', kRch, nRch
 
   ! NOTE: Reaches are ordered
   !        -->  kRch cannpt be processed until all upstream reaches are processed

--- a/route/build/src/process_ntopo.f90
+++ b/route/build/src/process_ntopo.f90
@@ -410,9 +410,6 @@ end subroutine augment_ntopo
   ! loop through stream segments
   do iSeg=1,nSeg
 
-   ! print progress
-   if(mod(iSeg,1000000)==0) write(iulog,*) 'Copying to the old data structures: iSeg, nSeg = ', iSeg, nSeg
-
    ! ----- reach parameters -----
 
    ! copy data into the reach parameter structure

--- a/route/build/src/process_time.f90
+++ b/route/build/src/process_time.f90
@@ -9,11 +9,14 @@ USE dataTypes, ONLY: time                ! time data type
 USE time_utils_module, ONLY: extractTime       ! get time from units string
 USE time_utils_module, ONLY: compJulday,&      ! compute julian day
                               compJulday_noleap ! compute julian day for noleap calendar
+USE time_utils_module, only : compcalday,&      ! compute calendar date and time
+                              compcalday_noleap ! compute calendar date and time for noleap calendar
 implicit none
 
 ! privacy -- everything private unless declared explicitly
 private
 public::process_time
+public::process_calday
 
 contains
 
@@ -48,14 +51,50 @@ contains
 
  ! calculate the julian day for the start time
  select case(trim(calendar))
-  case ('noleap')
+  case ('noleap','365_day')
    call compjulday_noleap(timeStruct%iy,timeStruct%im,timeStruct%id,timeStruct%ih,timeStruct%imin,timeStruct%dsec,julianDate,ierr,cmessage)
   case ('standard','gregorian','proleptic_gregorian')
    call compjulday(timeStruct%iy,timeStruct%im,timeStruct%id,timeStruct%ih,timeStruct%imin,timeStruct%dsec,julianDate,ierr,cmessage)
-  case default; ierr=20; message=trim(message)//trim(calendar)//': calendar name invalid'; return
+  case default; ierr=20; message=trim(message)//trim(calendar)//': calendar invalid; accept either noleap, 365_day, standard, gregorian, or proleptic_gregorian'; return
  end select
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  end subroutine process_time
+
+ ! *********************************************************************
+ ! public subroutine: extract calendar date/time information from julian day
+ ! *********************************************************************
+ subroutine process_calday(&
+                          ! input
+                          julianDate,       & ! julian date
+                          calendar,         & ! calendar
+                          ! output
+                          datetime,         & ! calendar
+                          ierr, message)
+ implicit none
+ ! input
+ real(dp)          , intent(in)               :: julianDate       ! julian date
+ character(*)      , intent(in)               :: calendar         ! calendar string
+ ! output
+ type(time)        , intent(out)              :: datetime        ! time data structure
+ integer(i4b)      , intent(out)              :: ierr             ! error code
+ character(*)      , intent(out)              :: message          ! error message
+ ! --------------------------------------------------------------------------------------------------------------
+ ! local variables
+ character(len=strLen)           :: cmessage         ! error message of downwind routine
+ ! initialize error control
+ ierr=0; message='process_calday/'
+
+ ! calculate the julian day for the start time
+ select case(trim(calendar))
+  case ('noleap','365_day')
+   call compcalday_noleap(julianDate, datetime%iy,datetime%im,datetime%id,datetime%ih,datetime%imin,datetime%dsec, ierr, cmessage)
+  case ('standard','gregorian','proleptic_gregorian')
+   call compcalday(julianDate, datetime%iy,datetime%im,datetime%id,datetime%ih,datetime%imin,datetime%dsec, ierr, cmessage)
+  case default; ierr=20; message=trim(message)//trim(calendar)//': calendar invalid; accept either noleap, 365_day, standard, gregorian, or proleptic_gregorian'; return
+ end select
+ if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+ end subroutine process_calday
 
 end module process_time_module

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -87,9 +87,10 @@ module public_var
   character(len=strLen),public    :: case_name            = ''              ! name of simulation
   character(len=strLen),public    :: simStart             = ''              ! date string defining the start of the simulation
   character(len=strLen),public    :: simEnd               = ''              ! date string defining the end of the simulation
-  character(len=strLen),public    :: newFileFrequency     = 'annual'        ! frequency for new output files (day, month, annual)
-  logical(lgt)         ,public    :: isRestart            = .false.         ! restart option: True-> model run with restart, F -> model run with empty channels
-  character(len=strLen),public    :: fname_state_in       = ''              ! netCDF name of restart file if isRestart is true
+  character(len=strLen),public    :: newFileFrequency     = 'annual'        ! frequency for new output files (day, month, annual, single)
+  character(len=strLen),public    :: restart_write        = 'never'         ! restart write option: never-> N[n]ever write, L[l]ast -> write at last time step, S[s]pecified
+  character(len=strLen),public    :: restart_date         = charMissing     ! specifed restart date
+  character(len=strLen),public    :: fname_state_in       = charMissing     ! name of state file
   integer(i4b)         ,public    :: routOpt              = integerMissing  ! routing scheme options  0-> both, 1->IRF, 2->KWT, otherwise error
   integer(i4b)         ,public    :: doesBasinRoute       = 1               ! basin routing options   0-> no, 1->IRF, otherwise error
   integer(i4b)         ,public    :: doesAccumRunoff      = 1               ! option to delayed runoff accumulation over all the upstream reaches

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -110,7 +110,8 @@ contains
    case('<sim_start>');            simStart    = trim(cData)                       ! date string defining the start of the simulation
    case('<sim_end>');              simEnd      = trim(cData)                       ! date string defining the end of the simulation
    case('<newFileFrequency>');     newFileFrequency = trim(cData)                  ! frequency for new output files (day, month, annual, single)
-   case('<restart_opt>');          read(cData,*,iostat=io_error) isRestart         ! restart option: True-> model run with restart, F -> model run with empty channels
+   case('<restart_write>');        restart_write        = trim(cData)              ! restart write option: N[n]ever, L[l]ast
+   case('<restart_date>');         restart_date         = trim(cData)              ! specified restart date, yyyy-mm-dd (hh:mm:ss)
    case('<fname_state_in>');       fname_state_in  = trim(cData)                   ! filename for the channel states
    case('<route_opt>');            read(cData,*,iostat=io_error) routOpt           ! routing scheme options  0-> both, 1->IRF, 2->KWT, otherwise error
    case('<doesBasinRoute>');       read(cData,*,iostat=io_error) doesBasinRoute    ! basin routing options   0-> no, 1->IRF, otherwise error

--- a/route/build/src/standalone/get_basin_runoff.f90
+++ b/route/build/src/standalone/get_basin_runoff.f90
@@ -36,7 +36,6 @@ contains
   integer(i4b), intent(out)     :: ierr               ! error code
   character(*), intent(out)     :: message            ! error message
   ! local variables
-  real(dp)    , allocatable     :: basinRunoff(:)     ! basin runoff (m/s)
   character(len=strLen)         :: cmessage           ! error message from subroutine
 
   ! initialize error control
@@ -47,10 +46,6 @@ contains
                         iTime,                             & ! input: time index
                         runoff_data,                       & ! inout: runoff data structure
                         ierr, cmessage)                      ! output: error control
-  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-  ! allocate basinRunoff (local array)
-  allocate(basinRunoff(nHRU), stat=ierr)
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
   ! initialize runoff_data%basinRunoff
@@ -64,17 +59,15 @@ contains
   ! Get river network HRU runoff into runoff_data data structure
   if (is_remap) then ! remap LSM simulated runoff to the HRUs in the river network
 
-   call remap_runoff(runoff_data, remap_data, basinRunoff, ierr, cmessage)
+   call remap_runoff(runoff_data, remap_data, runoff_data%basinRunoff, ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
   else ! runoff is already remapped to river network HRUs
 
-   call sort_runoff(runoff_data, basinRunoff, ierr, cmessage)
+   call sort_runoff(runoff_data, runoff_data%basinRunoff, ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
   end if
-
-  runoff_data%basinRunoff=basinRunoff
 
  end subroutine get_hru_runoff
 

--- a/route/build/src/standalone/route_runoff.f90
+++ b/route/build/src/standalone/route_runoff.f90
@@ -100,13 +100,13 @@ do while (.not.finished)
   if(ierr/=0) call handle_err(ierr, cmessage)
   call t_stopf ('output')
 
+  call output_state(ierr, cmessage)
+  if(ierr/=0) call handle_err(ierr, cmessage)
+
   call update_time(finished, ierr, cmessage)
   if(ierr/=0) call handle_err(ierr, cmessage)
 
 end do
-
-call output_state(ierr, cmessage)
-if(ierr/=0) call handle_err(ierr, cmessage)
 
 call model_finalize(mpicom_route)
 

--- a/route/build/src/time_utils.f90
+++ b/route/build/src/time_utils.f90
@@ -374,7 +374,7 @@ contains
 
  ! Convert fractions of a day to time
  ! now find hour,min,second
- frac_day = julday - floor(julday)
+ frac_day = days - real(id, kind(dp))
  ih = floor((frac_day+1e-9)*hr_per_day)
 
  remainder = (frac_day+1e-9)*hr_per_day - ih

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -45,12 +45,12 @@ public::prep_output
 public::output
 public::close_output_nc
 
-contains
+CONTAINS
 
  ! *********************************************************************
  ! public subroutine: define routing output NetCDF file
  ! *********************************************************************
- subroutine output(ierr, message)
+ SUBROUTINE output(ierr, message)
 
   ! global data required only this routine
   USE globalData, ONLY: RCHFLX_main         ! mainstem Reach fluxes (ensembles, space [reaches])
@@ -116,8 +116,8 @@ contains
   call write_netcdf(pioFileDesc, 'time', [timeVar(iTime)], [jTime], [1], ierr, cmessage)
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-  ! write the basin runoff to the netcdf file
   if (meta_rflx(ixRFLX%basRunoff)%varFile) then
+    ! write the basin runoff at HRU (unit: the same as runoff input)
     call write_pnetcdf_recdim(pioFileDesc, 'basRunoff',basinRunoff, iodesc_hru_ro, jTime, ierr, cmessage)
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   endif
@@ -158,7 +158,7 @@ contains
      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   endif
 
- end subroutine output
+ END SUBROUTINE output
 
 
  ! *********************************************************************
@@ -199,7 +199,7 @@ contains
 
   ! get the time
   select case(trim(calendar))
-   case('noleap')
+   case('noleap','365_day')
     call compCalday_noleap(modJulday,modTime(1)%iy,modTime(1)%im,modTime(1)%id,modTime(1)%ih,modTime(1)%imin,modTime(1)%dsec,ierr,cmessage)
    case ('standard','gregorian','proleptic_gregorian')
     call compCalday(modJulday,modTime(1)%iy,modTime(1)%im,modTime(1)%id,modTime(1)%ih,modTime(1)%imin,modTime(1)%dsec,ierr,cmessage)
@@ -209,7 +209,7 @@ contains
 
   ! print progress
   if (masterproc) then
-    write(iulog,*) modTime(1)%iy,modTime(1)%im,modTime(1)%id,modTime(1)%ih,modTime(1)%imin
+    write(iulog,'(a,I4,4(x,I4))') new_line('a'), modTime(1)%iy, modTime(1)%im, modTime(1)%id, modTime(1)%ih, modTime(1)%imin
   endif
 
   ! check need for the new file
@@ -231,7 +231,7 @@ contains
    jTime=1
 
    ! Define filename
-   sec_in_day = 0
+   sec_in_day = modTime(1)%ih*60*60+modTime(1)%imin*60+nint(modTime(1)%dsec)
    write(fileout, fmtYMDS) trim(output_dir)//trim(case_name)//'.mizuRoute.h.', &
                            modTime(1)%iy, '-', modTime(1)%im, '-', modTime(1)%id, '-',sec_in_day,'.nc'
 


### PR DESCRIPTION
### 1. restart file related changes.
1.1. Restart file drop-off timing. Now use <restart_write> and <restart_date> to control when restart file is written and start with restart file if <fname_state_in> is given (read_control.f90).
1.2. Moved `call output_state` within time stepping loop.
1.2. restart file name also use similar convention as output file name.
1.3. Use new Julidan day variables: restartJulday (restart drop-off Julian day) and roJulday (Julidan day series in runoff data)

### 2. Other time related changes
2.1. Added process_calday to compute calendar date from Julian day.  This is reverse function to process_time (compute Julian day from calendar date)
2.2. 365_day calendar is allowed (the same as noleap), 
2.3. Bugfix in noleap calendar computation - subdaily fractional day part.
2.4. Check start_sim, end_sim against runoff data time period.
2.5. Output file name use sub-daily time as second = sssss in case_name.h.mizuRoute.yyyy-mm-dd.sssss.nc.

### 3. Some status print outs are removed.