### PR TITLE
Feature/mpi-pio

### DIFF
--- a/route/build/src/time_utils.f90
+++ b/route/build/src/time_utils.f90
@@ -98,7 +98,10 @@ contains
 
  ! get the second
  istart = istart+iend
- if(istart > len_trim(refdate)) return
+ ! if second is missing (e.g., yyyy-mm-dd hh:mm)...
+ if(istart > len_trim(refdate)) then
+   dsec=0._dp; return
+ end if
  iend   = index(refdate(istart:n)," ")
  read(refdate(istart:n),*) dsec
  !write(*,'(a,i4,1x,4(i2,1x))') 'refdate: iyyy, im, id, ih, imin = ', iyyy, im, id, ih, imin

--- a/route/build/src/write_restart_pio.f90
+++ b/route/build/src/write_restart_pio.f90
@@ -80,7 +80,7 @@ CONTAINS
   integer(i4b),   intent(out)          :: ierr             ! error code
   character(*),   intent(out)          :: message          ! error message
   ! local variables
-  character(len=strLen)                :: fileout_state    ! name of the output file
+  character(len=300)                   :: fileout_state    ! name of the output file
   integer(i4b)                         :: sec_in_day       ! second within day
   character(len=strLen)                :: cmessage         ! error message of downwind routine
   character(len=50),parameter          :: fmtYMDS   = '(a,I0.4,a,I0.2,a,I0.2,a,I0.5,a)'

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -30,7 +30,7 @@ USE pio_utils
 implicit none
 
 ! The following variables used only in this module
-character(len=strLen),save :: fileout              ! name of the output file
+character(300),       save :: fileout              ! name of the output file
 integer(i4b),         save :: jTime                ! time step in output netCDF
 type(iosystem_desc_t),save :: pioSystem            ! PIO I/O system data
 type(file_desc_t),    save :: pioFileDesc          ! PIO data identifying the file

--- a/route/settings/SAMPLE.control
+++ b/route/settings/SAMPLE.control
@@ -5,43 +5,51 @@
 ! ****************************************************************************************************************************
 ! Note: lines starting with "!" are treated as comment lines -- there is no limit on the number of comment lines.
 !       lines starting with <xxx> are read till "!"
+!       Do not inclue empty line without !
+!
+!       Followings are example of control options.  if valid variables are inserted, they are default values.
 !
 ! ****************************************************************************************************************************
-! PART 1: DEFINE DIRECTORIES 
-! --------------------------
-<ancil_dir>        ANCIL_DIR                       ! directory containing ancillary data (runoff mapping data, river network data)
-<input_dir>        INPUT_DIR                       ! directory containing input data (runoff data)
-<output_dir>       OUTPUT_DIR                      ! directory containing output data
-! ****************************************************************************************************************************
-! PART 2: DEFINE TIME PERIOD OF THE SIMULATION
+! RUN CONTROL 
 ! --------------------------------------------
-<sim_start>        yyyy-mm-dd                      ! time of simulation start (year-month-day)
-<sim_end>          yyyy-mm-dd                      ! time of simulation end (year-month-day)
+<case_name>             CASE_NAME                  ! name of simulation
+<sim_start>             yyyy-mm-dd hh:mm:ss        ! time of simulation start. hh:mm:ss can be omitted
+<sim_end>               yyyy-mm-dd hh:mm:ss        ! time of simulation end. hh:mm:ss can be omitted 
+<route_opt>             0                          ! option for routing schemes 0-> both, 1->IRF, 2->KWT otherwise error 
+<doesBasinRoute>        1                          ! basin routing options   0-> no, 1->IRF, otherwise error
+<doesAccumRunoff>       1                          ! option to delayed runoff accumulation over all the upstream reaches. 0->no, 1->yes
+<restart_write>         Never                      ! restart write options. options: N[n]ever, L[l]ast, S[s]pecified 
+<restart_date>          yyyy-mm-dd hh:mm:ss        ! restart date.  activated only if <restart_write> is "specified" 
+<fname_state_in>        INPUT_RESTART_NC           ! input restart netCDF name. remove for run without any particular initial channel states
 ! ****************************************************************************************************************************
-! PART 3: DEFINE FINE NAME AND DIMENSIONS
+! DEFINE DIRECTORIES 
+! --------------------------
+<ancil_dir>             ANCIL_DIR                  ! directory containing ancillary data (runoff mapping data, river network data)
+<input_dir>             INPUT_DIR                  ! directory containing input data (runoff data)
+<output_dir>            OUTPUT_DIR                 ! directory containing output data
+! ****************************************************************************************************************************
+! DEFINE FINE NAME AND DIMENSIONS
 ! ---------------------------------------
-<fname_ntopOld>    NTOPO_NC                        ! netCDF name for River Network
-<dname_sseg>       DIMNAME_SEG                     ! dimension name of the stream segments
-<dname_nhru>       DIMNAME_HRU                     ! dimension name of the HRUs
-<ntopWriteOption>  F                               ! logical whether or not augmented river network is written 
-<fname_ntopNew>    UPDATED_NTOPO_NC                ! netCDF name for augmented River Network
+<fname_ntopOld>         NTOPO_NC                   ! netCDF name for River Network
+<dname_sseg>            DIMNAME_SEG                ! dimension name of the stream segments
+<dname_nhru>            DIMNAME_HRU                ! dimension name of the HRUs
 ! ****************************************************************************************************************************
-! PART 4: DEFINE DESIRED VARIABLES FOR THE NETWORK TOPOLOGY
+! DEFINE DESIRED VARIABLES FOR THE NETWORK TOPOLOGY
 ! ---------------------------------------------------------
-<seg_outlet>       -9999                           ! seg_id of outlet streamflow segment. -9999 for all segments 
+<seg_outlet>            -9999                      ! seg_id of outlet streamflow segment. -9999 for all segments 
 ! ****************************************************************************************************************************
-! PART 5: DEFINE RUNOFF FILE
+! DEFINE RUNOFF FILE
 ! ----------------------------------
-<fname_qsim>       RUNOFF_NC                       ! name of file containing the HRU runoff
-<vname_qsim>       VARNAME_RUNOFF                  ! name of HRU runoff variable
-<vname_time>       VARNAME_TIME                    ! name of time variable 
-<vname_hruid>      VARNAME_RO_HRU                  ! name of runoff HRU id variable (if 1D runoff vector is input)
-<dname_xlon>       DIMNAME_XLON                    ! name of x(j) dimension (if 2D runoff grid is input)
-<dname_ylat>       DIMNAME_YLAT                    ! name of y(i) dimension (if 2D runoff grid is input)
-<dname_time>       DIMNAME_TIME                    ! name of time dimension 
-<dname_hruid>      DIMNAME_RO_HRU                  ! name of the HRU dimension (if 1D runoff vector is input) 
-<units_qsim>       mm/s                            ! units of runoff e.g., mm/s
-<dt_qsim>          86400                           ! time interval of the runoff [sec] e.g., 86400 sec for daily step
+<fname_qsim>            RUNOFF_NC                  ! name of file containing the HRU runoff
+<vname_qsim>            VARNAME_RUNOFF             ! name of HRU runoff variable
+<vname_time>            VARNAME_TIME               ! name of time variable 
+<vname_hruid>           VARNAME_RO_HRU             ! name of runoff HRU id variable (if 1D runoff vector is input)
+<dname_xlon>            DIMNAME_XLON               ! name of x(j) dimension (if 2D runoff grid is input)
+<dname_ylat>            DIMNAME_YLAT               ! name of y(i) dimension (if 2D runoff grid is input)
+<dname_time>            DIMNAME_TIME               ! name of time dimension 
+<dname_hruid>           DIMNAME_RO_HRU             ! name of the HRU dimension (if 1D runoff vector is input) 
+<units_qsim>            mm/s                       ! units of runoff e.g., mm/s
+<dt_qsim>               86400                      ! time interval of the runoff [sec] e.g., 86400 sec for daily step
 ! ****************************************************************************************************************************
 ! PART 6: DEFINE RUNOFF MAPPING FILE 
 !  ----------------------------------
@@ -56,36 +64,48 @@
 <vname_i_index>         DIMNAME_I_INDEX            ! name of ylat index dimension (if 2D runoff grid is input) 
 <vname_j_index>         DIMNAME_J_INDEX            ! name of xlon index dimension (if 2D runoff grid is input)
 ! ****************************************************************************************************************************
-! PART 7 DEFINE RUN CONTROL 
-! ---------------------------
-<restart_opt>          F                           ! option to use saved flow states T->yes, F->No (start with empty channels) 
-<route_opt>            2                           ! option for routing schemes 0-> both, 1->IRF, 2->KWT otherwise error 
-! ****************************************************************************************************************************
-! PART 8: DEFINE OUTPUT FILE
-! ---------------------------
-<fname_output>         Q_OUT_NC                    ! filename for the model output
-<fname_state_in>       STATE_IN_NC                 ! filename for the channel states input 
-<fname_state_out>      STATE_OUT_NC                ! filename for the channel states output
-! ****************************************************************************************************************************
-! Part 9: Define options to include/skip calculations
+! Define options to include/skip calculations
 ! ----------------------------------------------------
-<hydGeometryOption>    1                           ! option for hydraulic geometry calculations (0=read from file, 1=compute)
-<topoNetworkOption>    1                           ! option for network topology calculations (0=read from file, 1=compute)
-<computeReachList>     1                           ! option to compute list of upstream reaches (0=do not compute, 1=compute)
+<hydGeometryOption>     1                          ! option for hydraulic geometry calculations (0=read from file, 1=compute)
+<topoNetworkOption>     1                          ! option for network topology calculations (0=read from file, 1=compute)
+<computeReachList>      1                          ! option to compute list of upstream reaches (0=do not compute, 1=compute)
 ! ****************************************************************************************************************************
-! PART 10: Namelist file name 
+! Namelist file name 
 ! ---------------------------
-<param_nml>            PARAMETER_NML               ! Namelist name containing routing parameter values 
+<param_nml>             PARAMETER_NML              ! Namelist name containing routing parameter values 
 ! ****************************************************************************************************************************
-! Part 11: Dictionary to map variable names
+! Dictionary to map variable names
 ! ---------------------------
-<varname_area>         Basin_Area                  ! name of variable holding hru area
-<varname_length>       Length                      ! name of variable holding segment length
-<varname_slope>        Slope                       ! name of variable holding segment slope
-<varname_HRUid>        hruid                       ! name of variable holding HRU id
-<varname_hruSegId>     seg_hru_id                  ! name of variable holding the stream segment below each HRU  
-<varname_segId>        seg_id                      ! name of variable holding the ID of each stream segment  
-<varname_downSegId>    tosegment                   ! name of variable holding the ID of the next downstream segment
+<varname_area>          Basin_Area                 ! name of variable holding hru area
+<varname_length>        Length                     ! name of variable holding segment length
+<varname_slope>         Slope                      ! name of variable holding segment slope
+<varname_HRUid>         hruid                      ! name of variable holding HRU id
+<varname_hruSegId>      seg_hru_id                 ! name of variable holding the stream segment below each HRU  
+<varname_segId>         seg_id                     ! name of variable holding the ID of each stream segment  
+<varname_downSegId>     tosegment                  ! name of variable holding the ID of the next downstream segment
 ! ****************************************************************************************************************************
 ! ****************************************************************************************************************************
 ! ****************************************************************************************************************************
+!
+! Some of useful input options
+! See read_control.f90 for complete options
+!
+! ****************************************************************************************************************************
+! Network augmentation
+! ---------------------------
+<ntopAugmentMode>       F                          ! option for river network augmentation mode
+<fname_ntopNew>         AUGMENTED_NTOPO_NC         ! name of augmented river network netCDF
+! ****************************************************************************************************************************
+! debugging  
+! ---------------------------
+<debug>                 F                          ! print out detailed information throught the probram
+<desireId>              -9999                      ! turn off checks (-999) or speficy reach ID if necessary to print on screen
+! ****************************************************************************************************************************
+! output options
+! ---------------------------
+<basRunoff>             T                          ! output options
+<instRunoff>            T                          ! output options
+<dlayRunoff>            T                          ! output options
+<sumUpstreamRunoff>     T                          ! output options
+<KWTroutedRunoff>       T                          ! output options
+<IRFroutedRunoff>       T                          ! output options 


### PR DESCRIPTION
1. Allow longer full path to output file names (coupler version sometime has long case name.....)
2. For some runoff data, time unit (in attribute) does not have second (i.e., since yyyy-mm-dd hh:mm). In this case, `dsec` need to be explicitly assigned to 0, before return. 