### PR TITLE
Spatial weight data handling

### DIFF
--- a/route/build/src/read_remap.f90
+++ b/route/build/src/read_remap.f90
@@ -81,6 +81,95 @@ contains
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  end do  ! looping through variables
 
+ ! check data
+ call check_remap_data(remap_data_in, ierr, cmessage)
+ if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+ end subroutine
+
+ ! *****
+ ! public subroutine: check spatial weight files
+ ! ********************************************************************************
+ subroutine check_remap_data(remap_data_in, &   ! inout: data structure to remap data
+                             ierr, message)     ! output: error control
+ USE dataTypes,          ONLY : remap           ! remapping data type
+ USE nr_utility_module,  ONLY : arth
+ implicit none
+ ! input/output variables
+ type(remap),  intent(inout)        :: remap_data_in     ! data structure to remap data from a polygon (e.g., grid) to another polygon (e.g., basin)
+ ! output variables
+ integer(i4b), intent(out)          :: ierr              ! error code
+ character(*), intent(out)          :: message           ! error message
+ ! local variables
+ integer(i4b)                       :: ix,jx             ! index of variables
+ integer(i4b), allocatable          :: idxZero(:)        ! indices where array variables are zero
+ integer(i4b)                       :: nHRU_map          ! number of HRU in mapping files (this should match up with river network hru)
+ integer(i4b)                       :: nData             ! number of data (weight, runoff hru id) in mapping files
+ integer(i4b)                       :: total_intersects  ! sum of intersected hydrologic model hrus over the entire routing HRUs
+ integer(i4b)                       :: nZero             ! number of array variables with zero
+ logical(lgt), allocatable          :: logical_array(:)  !
+ real(dp),     allocatable          :: real_array(:)     !
+ integer(i4b), allocatable          :: int_array(:)      !
+ character(len=strLen)              :: cmessage          ! error message from subroutine
+
+ ! initialize error control
+ ierr=0; message='check_remap_data/'
+
+ total_intersects = sum(remap_data_in%num_qhru)
+ nData            = size(remap_data_in%weight)
+ nHRU_map         = size(remap_data_in%num_qhru)
+
+ write(iulog,'(2a)') new_line('a'), 'Check total intersected hydrologic model hrus'
+ write(iulog,'(3a,I7)') ' 1) sum of ', trim(vname_num_qhru),    '= ', total_intersects
+ write(iulog,'(3a,I7)') ' 2) size of ', trim(dname_data_remap), '= ', nData
+
+ if (total_intersects == nData) then
+   write(iulog,'(a)') ' 1) and 2) identical. Should be good to go'
+ else
+   write(iulog,'(a)')    ' 1) and 2) differ'
+   write(iulog,'(3a)')   ' Correct ',trim(dname_data_remap),' dimension variables at routing HRUs without any interesected hydrologic model hrus'
+
+   nZero=count(remap_data_in%num_qhru==0)
+
+   allocate(logical_array(nData))
+   logical_array = .true.
+
+   if (nZero>0) then
+     allocate(idxZero(nZero))
+     idxZero = pack(arth(1,1,nHRU_map), remap_data_in%num_qhru==0)
+     do ix = 1,nZero
+       jx = sum(remap_data_in%num_qhru(1:idxZero(ix)))+1
+       logical_array(jx) = .false.
+     end do
+
+     allocate(real_array(total_intersects), int_array(total_intersects))
+     if (allocated(remap_data_in%qhru_id)) then
+       real_array = pack(remap_data_in%weight, logical_array)
+       deallocate(remap_data_in%weight)
+       allocate(remap_data_in%weight(total_intersects))
+       remap_data_in%weight = real_array
+     end if
+     if (allocated(remap_data_in%qhru_id)) then
+       int_array = pack(remap_data_in%qhru_id, logical_array)
+       deallocate(remap_data_in%qhru_id)
+       allocate(remap_data_in%qhru_id(total_intersects))
+       remap_data_in%qhru_id = int_array
+     end if
+     if (allocated(remap_data_in%i_index)) then
+       int_array = pack(remap_data_in%i_index, logical_array)
+       deallocate(remap_data_in%i_index)
+       allocate(remap_data_in%i_index(total_intersects))
+       remap_data_in%i_index = int_array
+     end if
+     if (allocated(remap_data_in%j_index)) then
+       int_array = pack(remap_data_in%j_index, logical_array)
+       deallocate(remap_data_in%j_index)
+       allocate(remap_data_in%j_index(total_intersects))
+       remap_data_in%j_index = int_array
+     end if
+   end if
+ end if
+
  end subroutine
 
 end module read_remap


### PR DESCRIPTION
Issue: For some spatial weight files, if there is no hydrologic model hrus within routing hru (ovelaps=0), zero is assigned to corresponding elements in data dimension variables (weight, and overlapPolyId). This means sum of overlaps over the entire routing hrus does not match with data dimension size. Current remap procedure (remap.f90) does not increment data dimension when such routing hrus are encountered when looping through routing hru.

New check_remap_data routing checks this and remove the elements in data dimension variables corresponding to such zero overlapping-routing hrus, so that the sum of overlaps is equal to the size of data dimension.
