### PR TITLE
Mods/bugfix on time related routines

### DIFF
--- a/route/build/src/process_time.f90
+++ b/route/build/src/process_time.f90
@@ -1,4 +1,4 @@
-module process_time_module
+MODULE process_time_module
 
 ! data types
 USE nrtype,    only : i4b,dp              ! variable types, etc.
@@ -11,19 +11,21 @@ USE time_utils_module, only : compJulday,&      ! compute julian day
                               compJulday_noleap ! compute julian day for noleap calendar
 USE time_utils_module, only : compcalday,&      ! compute calendar date and time
                               compcalday_noleap ! compute calendar date and time for noleap calendar
+
 implicit none
 
 ! privacy -- everything private unless declared explicitly
 private
 public::process_time
-public::process_calday
+public::conv_cal2julian
+public::conv_julian2cal
 
-contains
+CONTAINS
 
  ! *********************************************************************
  ! public subroutine: extract time information from the control information
  ! *********************************************************************
- subroutine process_time(&
+ SUBROUTINE process_time(&
                          ! input
                          timeUnits,        & ! time units string
                          calendar,         & ! calendar
@@ -42,50 +44,39 @@ contains
  ! local variables
  type(time)                      :: timeStruct       ! time data structure
  character(len=strLen)           :: cmessage         ! error message of downwind routine
- ! initialize error control
+
  ierr=0; message='process_time/'
 
  ! extract time from the units string
  call extractTime(timeUnits,timeStruct%iy,timeStruct%im,timeStruct%id,timeStruct%ih,timeStruct%imin,timeStruct%dsec,ierr,cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- ! calculate the julian day for the start time
- select case(trim(calendar))
-  case ('noleap','365_day')
-   call compjulday_noleap(timeStruct%iy,timeStruct%im,timeStruct%id,timeStruct%ih,timeStruct%imin,timeStruct%dsec,julianDate,ierr,cmessage)
-  case ('standard','gregorian','proleptic_gregorian')
-   call compjulday(timeStruct%iy,timeStruct%im,timeStruct%id,timeStruct%ih,timeStruct%imin,timeStruct%dsec,julianDate,ierr,cmessage)
-  case default; ierr=20; message=trim(message)//trim(calendar)//': calendar invalid; accept either noleap, 365_day, standard, gregorian, or proleptic_gregorian'; return
- end select
+ call conv_cal2julian(timeStruct, calendar, julianDate, ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- end subroutine process_time
+ END SUBROUTINE process_time
 
  ! *********************************************************************
- ! public subroutine: extract calendar date/time information from julian day
+ ! public subroutine: convert julian date to calendar date/time
  ! *********************************************************************
- subroutine process_calday(&
-                          ! input
-                          julianDate,       & ! julian date
-                          calendar,         & ! calendar
-                          ! output
-                          datetime,         & ! calendar
-                          ierr, message)
+ SUBROUTINE conv_julian2cal(julianDate,       & ! input: julian date
+                            calendar,         & ! input: calendar
+                            datetime,         & ! output: calendar date/time
+                            ierr, message)
  implicit none
  ! input
  real(dp)          , intent(in)               :: julianDate       ! julian date
  character(*)      , intent(in)               :: calendar         ! calendar string
  ! output
- type(time)        , intent(out)              :: datetime        ! time data structure
+ type(time)        , intent(out)              :: datetime         ! time data structure
  integer(i4b)      , intent(out)              :: ierr             ! error code
  character(*)      , intent(out)              :: message          ! error message
  ! --------------------------------------------------------------------------------------------------------------
  ! local variables
  character(len=strLen)           :: cmessage         ! error message of downwind routine
- ! initialize error control
- ierr=0; message='process_calday/'
 
- ! calculate the julian day for the start time
+ ierr=0; message='conv_julian2cal/'
+
  select case(trim(calendar))
   case ('noleap','365_day')
    call compcalday_noleap(julianDate, datetime%iy,datetime%im,datetime%id,datetime%ih,datetime%imin,datetime%dsec, ierr, cmessage)
@@ -95,6 +86,39 @@ contains
  end select
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- end subroutine process_calday
+ END SUBROUTINE conv_julian2cal
 
-end module process_time_module
+ ! *********************************************************************
+ ! public subroutine: convert calendar date/time to julian days
+ ! *********************************************************************
+ SUBROUTINE conv_cal2julian(datetime,         & ! input: calendar date
+                            calendar,         & ! input: calendar
+                            julianDate,       & ! output: julian date
+                            ierr, message)
+ implicit none
+ ! input
+ type(time)        , intent(in)               :: datetime         ! time data structure
+ character(*)      , intent(in)               :: calendar         ! calendar string
+ ! output
+ real(dp)          , intent(out)              :: julianDate       ! julian date
+ integer(i4b)      , intent(out)              :: ierr             ! error code
+ character(*)      , intent(out)              :: message          ! error message
+ ! --------------------------------------------------------------------------------------------------------------
+ ! local variables
+ character(len=strLen)           :: cmessage         ! error message of downwind routine
+
+ ierr=0; message='conv_cal2julian/'
+
+ select case(trim(calendar))
+  case ('noleap','365_day')
+   call compjulday_noleap(datetime%iy, datetime%im, datetime%id, datetime%ih, datetime%imin, datetime%dsec, julianDate, ierr, cmessage)
+  case ('standard','gregorian','proleptic_gregorian')
+   call compjulday(datetime%iy, datetime%im, datetime%id, datetime%ih, datetime%imin, datetime%dsec, julianDate, ierr, cmessage)
+  case default; ierr=20; message=trim(message)//trim(calendar)//': calendar invalid; accept either noleap, 365_day, standard, gregorian, or proleptic_gregorian'; return
+ end select
+ if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+ END SUBROUTINE conv_cal2julian
+
+
+END MODULE process_time_module

--- a/route/build/src/time_utils.f90
+++ b/route/build/src/time_utils.f90
@@ -64,7 +64,7 @@ contains
  ! input
  integer(i4b),intent(in)           :: yr
  integer(i4b),intent(in)           :: mo
- character(len=strLen),intent(in)  :: calendar
+ character(*),intent(in)           :: calendar
  ! output
  integer(i4b)         ,intent(out) :: ndays     !
  integer(i4b),         intent(out) :: ierr         ! error code


### PR DESCRIPTION
- Use assumed character length for subroutine argument so that the subroutine call does not require exactly the same string length for argument (ndays_month).
- Create Julian date - calendar date conversion routines.  