### PR TITLE
Develop

### DIFF
--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -115,7 +115,9 @@ module globalData
   real(dp)        , allocatable  , public :: timeVar(:)           ! time variables (unit given by time variable)
   real(dp)                       , public :: TSEC(0:1)            ! begning and end of time step (sec)
   type(time)                     , public :: modTime(0:1)         ! previous and current model time (yyyy:mm:dd:hh:mm:ss)
-  type(time)                     , public :: restCal         ! previous and current model time (yyyy:mm:dd:hh:mm:ss)
+  type(time)                     , public :: restCal              ! desired restart date/time (yyyy:mm:dd:hh:mm:ss)
+  type(time)                     , public :: dropCal              ! restart dropoff date/time (yyyy:mm:dd:hh:mm:ss)
+  logical(lgt)                   , public :: restartAlarm         ! alarm to triger restart file writing
 
   ! simulation output netcdf
   type(nc)                       , public :: simout_nc

--- a/route/build/src/route_runoff.f90
+++ b/route/build/src/route_runoff.f90
@@ -14,12 +14,12 @@ USE model_setup,         only : init_model       ! model setupt - reading contro
 USE model_setup,         only : init_data        ! initialize river reach data
 USE model_setup,         only : update_time      ! Update simulation time information at each time step
 ! subroutines: routing
-USE main_route_module,   only : main_route       !
+USE main_route_module,   only : main_route       ! main routing routine
 ! subroutines: model I/O
 USE get_runoff        ,  only : get_hru_runoff   !
 USE write_simoutput,     only : prep_output      !
 USE write_simoutput,     only : output           !
-USE write_restart,       only : output_state     ! write netcdf state output file
+USE write_restart,       only : main_restart     ! write netcdf restart file
 
 implicit none
 
@@ -68,11 +68,9 @@ if(ierr/=0) call handle_err(ierr, cmessage)
 ! ***********************************
 do while (.not.finished)
 
-  ! prepare simulation output netCDF
   call prep_output(ierr, cmessage)
   if(ierr/=0) call handle_err(ierr, cmessage)
 
-  ! Get river network hru runoff at current time step
 call system_clock(startTime)
   call get_hru_runoff(ierr, cmessage)
   if(ierr/=0) call handle_err(ierr, cmessage)
@@ -94,14 +92,13 @@ call system_clock(endTime)
 elapsedTime = real(endTime-startTime, kind(dp))/real(cr)
 write(*,"(A,1PG15.7,A)") '   elapsed-time [output] = ', elapsedTime, ' s'
 
-  ! write state netCDF
-  call output_state(ierr, cmessage)
+  call main_restart(ierr, cmessage)
   if(ierr/=0) call handle_err(ierr, cmessage)
 
   call update_time(finished, ierr, cmessage)
   if(ierr/=0) call handle_err(ierr, cmessage)
 
-end do  ! looping through time
+end do
 
 stop
 


### PR DESCRIPTION
The purpose is to fix issue on the restart dropoff timing when a user specifies "annual" or "monthly" for restart_write option with "restart_day" is some of end-of-month days (29, 30, or 31).  Use dropCal (dropoff calendar date/time) and restCal (restart calendar date/time) to control dropoff timing.

Other changes is re-organization in write_restart module, and some minor changes related to this in main program (route_runoff.f90)
