### PR TITLE
fillvalue in runoff input data

### DIFF
--- a/route/build/src/ncio_utils.f90
+++ b/route/build/src/ncio_utils.f90
@@ -11,6 +11,7 @@ public::get_nc
 public::get_var_dims
 public::get_nc_dim_len
 public::get_var_attr
+public::check_attr
 public::put_global_attr
 public::def_nc
 public::def_dim
@@ -210,6 +211,36 @@ CONTAINS
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
  end subroutine
+
+ ! *********************************************************************
+ ! subroutine: check if attribute exists
+ ! *********************************************************************
+ FUNCTION check_attr(fname, vname, attr_name)
+   implicit none
+   ! input
+   character(*), intent(in)        :: fname        ! filename
+   character(*), intent(in)        :: vname        ! variable name
+   character(*), intent(in)        :: attr_name    ! attribute name
+   logical(lgt)                    :: check_attr
+   ! local
+   integer(i4b)                    :: ierr         ! error code
+   integer(i4b)                    :: ncid         ! NetCDF file ID
+   integer(i4b)                    :: iVarID       ! variable ID
+
+   ! open file for reading
+   ierr = nf90_open(fname, nf90_nowrite, ncid)
+
+   ! get the ID of the variable
+   ierr = nf90_inq_varid(ncid, trim(vname), iVarID)
+
+   ierr = nf90_inquire_attribute(ncid, iVarID, attr_name)
+   check_attr = (ierr == nf90_noerr)
+
+  ! close output file
+  ierr = nf90_close(ncid)
+
+ END FUNCTION check_attr
+
 
  ! *********************************************************************
  ! subroutine: get attribute values for a variable

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -116,6 +116,7 @@ module public_var
   character(len=strLen),public    :: dname_ylat           = ''              ! dimension name for y (i, latitude) dimension
   character(len=strLen),public    :: units_qsim           = ''              ! units of simulated runoff data
   real(dp)             ,public    :: dt                   = realMissing     ! time step (seconds)
+  real(dp)             ,public    :: input_fillvalue      = realMissing     ! fillvalue used for input variables (runoff, precipitation, evaporation)
   ! RUNOFF REMAPPING
   logical(lgt),public             :: is_remap             = .false.         ! logical whether or not runnoff needs to be mapped to river network HRU
   character(len=strLen),public    :: fname_remap          = ''              ! runoff mapping netCDF name

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -137,6 +137,7 @@ CONTAINS
    case('<dname_ylat>');           dname_ylat   = trim(cData)                      ! name of y (i,lat) dimension
    case('<units_qsim>');           units_qsim   = trim(cData)                      ! units of runoff
    case('<dt_qsim>');              read(cData,*,iostat=io_error) dt                ! time interval of the gridded runoff
+   case('<input_fillvalue>');      read(cData,*,iostat=io_error) input_fillvalue   ! fillvalue used for input variable
    ! RUNOFF REMAPPING
    case('<is_remap>');             read(cData,*,iostat=io_error) is_remap          ! logical whether or not runnoff needs to be mapped to river network HRU
    case('<fname_remap>');          fname_remap          = trim(cData)              ! name of runoff mapping netCDF

--- a/route/build/src/standalone/read_runoff.f90
+++ b/route/build/src/standalone/read_runoff.f90
@@ -6,9 +6,9 @@ USE public_var
 USE io_netcdf, only:open_nc
 USE io_netcdf, only:get_nc
 USE io_netcdf, only:get_var_attr
+USE io_netcdf, only:check_attr
 USE io_netcdf, only:get_nc_dim_len
 USE dataTypes, only:runoff                 ! runoff data type
-
 
 implicit none
 
@@ -248,7 +248,7 @@ contains
  ! local variables
  integer(i4b)                       :: iStart(2)
  integer(i4b)                       :: iCount(2)
- real(dp)                           :: fill_value         ! fill_value
+ logical(lgt)                       :: existFillVal
  real(dp)                           :: dummy(nSpace,1)    ! data read
  character(len=strLen)              :: cmessage           ! error message from subroutine
 
@@ -261,12 +261,15 @@ contains
  call get_nc(fname, var_name, dummy, iStart, iCount, ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- ! get the _fill_values for runoff variable
- call get_var_attr(trim(fname), trim(var_name), '_FillValue', fill_value, ierr, cmessage)
- if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ ! get the _fill_values for runoff variable if exist
+ existFillVal = check_attr(fname, var_name, '_FillValue')
+ if (existFillval) then
+   call get_var_attr(fname, var_name, '_FillValue', input_fillvalue, ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ end if
 
  ! replace _fill_value with -999 for dummy
- where ( abs(dummy - fill_value) < verySmall ) dummy = realMissing
+ where ( abs(dummy - input_fillvalue) < verySmall ) dummy = realMissing
 
  ! reshape
  runoff_data_in%sim(1:nSpace) = dummy(1:nSpace,1)
@@ -294,9 +297,9 @@ contains
  integer(i4b), intent(out)   :: ierr             ! error code
  character(*), intent(out)   :: message          ! error message
  ! local variables
+ logical(lgt)                :: existFillVal
  integer(i4b)                :: iStart(3)
  integer(i4b)                :: iCount(3)
- real(dp)                    :: fill_value                   ! fill_value
  real(dp)                    :: dummy(nSpace(2),nSpace(1),1) ! data read
  character(len=strLen)       :: cmessage                     ! error message from subroutine
 
@@ -310,11 +313,14 @@ contains
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  ! get the _fill_values for runoff variable
- call get_var_attr(trim(fname), trim(var_name), '_FillValue', fill_value, ierr, cmessage)
- if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ existFillVal = check_attr(fname, var_name, '_FillValue')
+ if (existFillval) then
+   call get_var_attr(fname, var_name, '_FillValue', input_fillvalue, ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ end if
 
  ! replace _fill_value with -999 for dummy
- where ( abs(dummy - fill_value) < verySmall ) dummy = realMissing
+ where ( abs(dummy - input_fillvalue) < verySmall ) dummy = realMissing
 
  ! reshape
  runoff_data_in%sim2d(1:nSpace(2),1:nSpace(1)) = dummy(1:nSpace(2),1:nSpace(1),1)


### PR DESCRIPTION
If runoff (or precip, evap) variable does not have _fillvalue in runoff netcdf, skip reading fillvalue, and use user-specified or default fillvalue. Default fillvalue is `realMissing=-9999._dp`. NOTE: If runoff netCDF does not have fillvalues, but missing value actually exists, user can (should) provide it in control file.  To check if the fillValue exist, check_attr subroutine is added   