### PR TITLE
More robust mapping file handling

### DIFF
--- a/route/build/src/standalone/read_remap.f90
+++ b/route/build/src/standalone/read_remap.f90
@@ -81,6 +81,94 @@ contains
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  end do  ! looping through variables
 
+ ! check data
+ call check_remap_data(remap_data_in, ierr, cmessage)
+ if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+ end subroutine
+
+ ! *****
+ ! public subroutine: check spatial weight files
+ ! ********************************************************************************
+ subroutine check_remap_data(remap_data_in, &   ! inout: data structure to remap data
+                             ierr, message)     ! output: error control
+ USE dataTypes,          ONLY : remap           ! remapping data type
+ USE nr_utility_module,  ONLY : arth
+ implicit none
+ ! input/output variables
+ type(remap),  intent(inout)        :: remap_data_in     ! data structure to remap data from a polygon (e.g., grid) to another polygon (e.g., basin)
+ ! output variables
+ integer(i4b), intent(out)          :: ierr              ! error code
+ character(*), intent(out)          :: message           ! error message
+ ! local variables
+ integer(i4b)                       :: ix,jx             ! index of variables
+ integer(i4b), allocatable          :: idxZero(:)        ! indices where array variables are zero
+ integer(i4b)                       :: nHRU_map          ! number of HRU in mapping files (this should match up with river network hru)
+ integer(i4b)                       :: nData             ! number of data (weight, runoff hru id) in mapping files
+ integer(i4b)                       :: total_intersects  ! sum of intersected hydrologic model hrus over the entire routing HRUs
+ integer(i4b)                       :: nZero             ! number of array variables with zero
+ logical(lgt), allocatable          :: logical_array(:)  !
+ real(dp),     allocatable          :: real_array(:)     !
+ integer(i8b), allocatable          :: int_array(:)      !
+
+ ! initialize error control
+ ierr=0; message='check_remap_data/'
+
+ total_intersects = sum(remap_data_in%num_qhru)
+ nData            = size(remap_data_in%weight)
+ nHRU_map         = size(remap_data_in%num_qhru)
+
+ write(iulog,'(2a)') new_line('a'), 'Check total intersected hydrologic model hrus'
+ write(iulog,'(3a,I7)') ' 1) sum of ', trim(vname_num_qhru),    '= ', total_intersects
+ write(iulog,'(3a,I7)') ' 2) size of ', trim(dname_data_remap), '= ', nData
+
+ if (total_intersects == nData) then
+   write(iulog,'(a)') ' 1) and 2) identical. Should be good to go'
+ else
+   write(iulog,'(a)')    ' 1) and 2) differ'
+   write(iulog,'(3a)')   ' Correct ',trim(dname_data_remap),' dimension variables at routing HRUs without any interesected hydrologic model hrus'
+
+   nZero=count(remap_data_in%num_qhru==0)
+
+   allocate(logical_array(nData))
+   logical_array = .true.
+
+   if (nZero>0) then
+     allocate(idxZero(nZero))
+     idxZero = pack(arth(1,1,nHRU_map), remap_data_in%num_qhru==0)
+     do ix = 1,nZero
+       jx = sum(remap_data_in%num_qhru(1:idxZero(ix)))+1
+       logical_array(jx) = .false.
+     end do
+
+     allocate(real_array(total_intersects), int_array(total_intersects))
+     if (allocated(remap_data_in%qhru_id)) then
+       real_array = pack(remap_data_in%weight, logical_array)
+       deallocate(remap_data_in%weight)
+       allocate(remap_data_in%weight(total_intersects))
+       remap_data_in%weight = real_array
+     end if
+     if (allocated(remap_data_in%qhru_id)) then
+       int_array = pack(remap_data_in%qhru_id, logical_array)
+       deallocate(remap_data_in%qhru_id)
+       allocate(remap_data_in%qhru_id(total_intersects))
+       remap_data_in%qhru_id = int_array
+     end if
+     if (allocated(remap_data_in%i_index)) then
+       int_array = pack(remap_data_in%i_index, logical_array)
+       deallocate(remap_data_in%i_index)
+       allocate(remap_data_in%i_index(total_intersects))
+       remap_data_in%i_index = int_array
+     end if
+     if (allocated(remap_data_in%j_index)) then
+       int_array = pack(remap_data_in%j_index, logical_array)
+       deallocate(remap_data_in%j_index)
+       allocate(remap_data_in%j_index(total_intersects))
+       remap_data_in%j_index = int_array
+     end if
+   end if
+ end if
+
  end subroutine
 
 end module read_remap


### PR DESCRIPTION
**Issue:** 
There seems to be two ways of handling the case where the river network HRU does not have any overlapping hydrologic model HRUs (ovelaps=0 in mapping file) in spatial weight file. One is skip the corresponding location in the data dimension variables, i.e., weight and overlapPolyId (sometime called intersector).  The second is put 0 in the corresponding location in data dimension variables.  

Examples:  river_hru=[1001, 1002, 1003, 1004, 1005]. overlaps=[2, 3, 1, 0, 4].  overlaps = number of overlapping hydrologic model HRUs

1st method: weight=[(0.2, 0.8), (0.2, 0.3, 0.5), (1.0), (0.1, 0.2, 0.3, 0.4)], overlapPolyId=[(11, 12), (21, 22, 23), (31), (51 ,52, 53, 54)]

2nd method: weight=[(0.2, 0.8), (0.2, 0.3, 0.5), (1.0), _(0.0)_, (0.1, 0.2, 0.3, 0.4)], overlapPolyId=[(11, 12), (21, 22, 23), (31), _(0)_, (51 ,52, 53, 54)]

Current remap procedure (remap.f90) does not increment data dimension when river network HRU w/o any hydrologic model HRUs is encountered when looping through data dimension. This causes problem if user provide the spatial weight file following the 2nd method

**Solution:** 
Generated new routine (check_remap_data) to check that if overlaps is 0 for river network HRU and 0 is assigned to the elements in weight/overlapIds, remove the 0 value elements in data dimension variables, so the sum of nOverlaps get equals to size of data dimension.