### PR TITLE
Feature/mpi pio restart

### DIFF
--- a/route/build/Makefile
+++ b/route/build/Makefile
@@ -150,6 +150,14 @@ UTILS = \
     pio_utils.f90 \
     model_utils.f90 \
     gamma_func.f90
+# initialization
+INIT = \
+    process_time.f90 \
+    network_topo.f90 \
+    process_param.f90 \
+    process_ntopo.f90 \
+    pfafstetter.f90 \
+    domain_decomposition.f90
 # read/write files
 IO = \
     remap.f90 \
@@ -163,14 +171,6 @@ IO = \
     read_restart.f90 \
     write_restart_pio.f90 \
     write_simoutput_pio.f90
-# initialization
-INIT = \
-    process_time.f90 \
-    network_topo.f90 \
-    process_param.f90 \
-    process_ntopo.f90 \
-    pfafstetter.f90 \
-    domain_decomposition.f90
 # CORE
 CORE = \
     accum_runoff.f90 \
@@ -184,7 +184,7 @@ CORE = \
     standalone/model_setup.f90
 
 # concatanate model subroutines
-TEMP_MODSUB = $(DATATYPES) $(UTILS) $(IO) $(INIT) $(CORE)
+TEMP_MODSUB = $(DATATYPES) $(UTILS) $(INIT) $(IO) $(CORE)
 
 # insert appropriate directory name
 MODSUB = $(patsubst %, $(F_KORE_DIR)%, $(TEMP_MODSUB))

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -78,11 +78,12 @@ module globalData
   real(dp)                       , public :: endJulday            ! julian day: end of routing simulation
   real(dp)                       , public :: refJulday            ! julian day: reference
   real(dp)                       , public :: modJulday            ! julian day: simulation time step
-  real(dp)                       , public :: restartJulday        ! julian day: restart drop off
   real(dp)        , allocatable  , public :: roJulday(:)          ! julian day: runoff input time
   real(dp)        , allocatable  , public :: timeVar(:)           ! time variables (unit given by runoff data)
   real(dp)                       , public :: TSEC(0:1)            ! begning and end of time step (sec)
   type(time)                     , public :: modTime(0:1)         ! previous and current model time (yyyy:mm:dd:hh:mm:ss)
+  type(time)                     , public :: restCal              ! desired restart date/time (yyyy:mm:dd:hh:mm:ss)
+  type(time)                     , public :: dropCal              ! restart dropoff date/time (yyyy:mm:dd:hh:mm:ss)
 
   ! ---------- input file information -------------------------------------------------------------------
 

--- a/route/build/src/mpi_process.f90
+++ b/route/build/src/mpi_process.f90
@@ -2026,7 +2026,6 @@ contains
   USE globalData, ONLY: startJulday       ! julian day: start
   USE globalData, ONLY: endJulday         ! julian day: end
   USE globalData, ONLY: modJulday         ! julian day: at simulation time step
-  USE globalData, ONLY: restartJulday     ! julian day: at restart
   USE globalData, ONLY: roJulday          ! julian day: runoff input time
   USE globalData, ONLY: reachID
   USE globalData, ONLY: basinID
@@ -2051,7 +2050,6 @@ contains
   call MPI_BCAST(startJulday,   1,   MPI_DOUBLE_PRECISION, root, comm, ierr)
   call MPI_BCAST(endJulday,     1,   MPI_DOUBLE_PRECISION, root, comm, ierr)
   call MPI_BCAST(modJulday,     1,   MPI_DOUBLE_PRECISION, root, comm, ierr)
-  call MPI_BCAST(restartJulday, 1,   MPI_DOUBLE_PRECISION, root, comm, ierr)
 
   call shr_mpi_bcast(roJulday,ierr, message)
   call shr_mpi_bcast(timeVar,ierr, message)

--- a/route/build/src/ncio_utils.f90
+++ b/route/build/src/ncio_utils.f90
@@ -11,6 +11,7 @@ public::get_nc
 public::get_var_dims
 public::get_nc_dim_len
 public::get_var_attr
+public::check_attr
 public::put_global_attr
 public::def_nc
 public::def_dim
@@ -210,6 +211,36 @@ CONTAINS
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
  end subroutine
+
+ ! *********************************************************************
+ ! subroutine: check if attribute exists
+ ! *********************************************************************
+ FUNCTION check_attr(fname, vname, attr_name)
+   implicit none
+   ! input
+   character(*), intent(in)        :: fname        ! filename
+   character(*), intent(in)        :: vname        ! variable name
+   character(*), intent(in)        :: attr_name    ! attribute name
+   logical(lgt)                    :: check_attr
+   ! local
+   integer(i4b)                    :: ierr         ! error code
+   integer(i4b)                    :: ncid         ! NetCDF file ID
+   integer(i4b)                    :: iVarID       ! variable ID
+
+   ! open file for reading
+   ierr = nf90_open(fname, nf90_nowrite, ncid)
+
+   ! get the ID of the variable
+   ierr = nf90_inq_varid(ncid, trim(vname), iVarID)
+
+   ierr = nf90_inquire_attribute(ncid, iVarID, attr_name)
+   check_attr = (ierr == nf90_noerr)
+
+  ! close output file
+  ierr = nf90_close(ncid)
+
+ END FUNCTION check_attr
+
 
  ! *********************************************************************
  ! subroutine: get attribute values for a variable

--- a/route/build/src/process_time.f90
+++ b/route/build/src/process_time.f90
@@ -1,4 +1,4 @@
-module process_time_module
+MODULE process_time_module
 
 ! data types
 USE nrtype,    ONLY: i4b,dp              ! variable types, etc.
@@ -8,22 +8,24 @@ USE dataTypes, ONLY: time                ! time data type
 ! subroutines: model time info
 USE time_utils_module, ONLY: extractTime       ! get time from units string
 USE time_utils_module, ONLY: compJulday,&      ! compute julian day
-                              compJulday_noleap ! compute julian day for noleap calendar
-USE time_utils_module, only : compcalday,&      ! compute calendar date and time
-                              compcalday_noleap ! compute calendar date and time for noleap calendar
+                             compJulday_noleap ! compute julian day for noleap calendar
+USE time_utils_module, ONLY: compcalday,&      ! compute calendar date and time
+                             compcalday_noleap ! compute calendar date and time for noleap calendar
+
 implicit none
 
 ! privacy -- everything private unless declared explicitly
 private
 public::process_time
-public::process_calday
+public::conv_cal2julian
+public::conv_julian2cal
 
-contains
+CONTAINS
 
  ! *********************************************************************
  ! public subroutine: extract time information from the control information
  ! *********************************************************************
- subroutine process_time(&
+ SUBROUTINE process_time(&
                          ! input
                          timeUnits,        & ! time units string
                          calendar,         & ! calendar
@@ -49,43 +51,32 @@ contains
  call extractTime(timeUnits,timeStruct%iy,timeStruct%im,timeStruct%id,timeStruct%ih,timeStruct%imin,timeStruct%dsec,ierr,cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- ! calculate the julian day for the start time
- select case(trim(calendar))
-  case ('noleap','365_day')
-   call compjulday_noleap(timeStruct%iy,timeStruct%im,timeStruct%id,timeStruct%ih,timeStruct%imin,timeStruct%dsec,julianDate,ierr,cmessage)
-  case ('standard','gregorian','proleptic_gregorian')
-   call compjulday(timeStruct%iy,timeStruct%im,timeStruct%id,timeStruct%ih,timeStruct%imin,timeStruct%dsec,julianDate,ierr,cmessage)
-  case default; ierr=20; message=trim(message)//trim(calendar)//': calendar invalid; accept either noleap, 365_day, standard, gregorian, or proleptic_gregorian'; return
- end select
+ call conv_cal2julian(timeStruct, calendar, julianDate, ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- end subroutine process_time
+ END SUBROUTINE process_time
 
  ! *********************************************************************
- ! public subroutine: extract calendar date/time information from julian day
+ ! public subroutine: convert julian date to calendar date/time
  ! *********************************************************************
- subroutine process_calday(&
-                          ! input
-                          julianDate,       & ! julian date
-                          calendar,         & ! calendar
-                          ! output
-                          datetime,         & ! calendar
-                          ierr, message)
+ SUBROUTINE conv_julian2cal(julianDate,       & ! input: julian date
+                            calendar,         & ! input: calendar
+                            datetime,         & ! output: calendar date/time
+                            ierr, message)
  implicit none
  ! input
  real(dp)          , intent(in)               :: julianDate       ! julian date
  character(*)      , intent(in)               :: calendar         ! calendar string
  ! output
- type(time)        , intent(out)              :: datetime        ! time data structure
+ type(time)        , intent(out)              :: datetime         ! time data structure
  integer(i4b)      , intent(out)              :: ierr             ! error code
  character(*)      , intent(out)              :: message          ! error message
  ! --------------------------------------------------------------------------------------------------------------
  ! local variables
  character(len=strLen)           :: cmessage         ! error message of downwind routine
 
- ierr=0; message='process_calday/'
+ ierr=0; message='conv_julian2cal/'
 
- ! calculate the julian day for the start time
  select case(trim(calendar))
   case ('noleap','365_day')
    call compcalday_noleap(julianDate, datetime%iy,datetime%im,datetime%id,datetime%ih,datetime%imin,datetime%dsec, ierr, cmessage)
@@ -95,6 +86,38 @@ contains
  end select
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- end subroutine process_calday
+ END SUBROUTINE conv_julian2cal
 
-end module process_time_module
+ ! *********************************************************************
+ ! public subroutine: convert calendar date/time to julian days
+ ! *********************************************************************
+ SUBROUTINE conv_cal2julian(datetime,         & ! input: calendar date
+                            calendar,         & ! input: calendar
+                            julianDate,       & ! output: julian date
+                            ierr, message)
+ implicit none
+ ! input
+ type(time)        , intent(in)               :: datetime         ! time data structure
+ character(*)      , intent(in)               :: calendar         ! calendar string
+ ! output
+ real(dp)          , intent(out)              :: julianDate       ! julian date
+ integer(i4b)      , intent(out)              :: ierr             ! error code
+ character(*)      , intent(out)              :: message          ! error message
+ ! --------------------------------------------------------------------------------------------------------------
+ ! local variables
+ character(len=strLen)           :: cmessage         ! error message of downwind routine
+
+ ierr=0; message='conv_cal2julian/'
+
+ select case(trim(calendar))
+  case ('noleap','365_day')
+   call compjulday_noleap(datetime%iy, datetime%im, datetime%id, datetime%ih, datetime%imin, datetime%dsec, julianDate, ierr, cmessage)
+  case ('standard','gregorian','proleptic_gregorian')
+   call compjulday(datetime%iy, datetime%im, datetime%id, datetime%ih, datetime%imin, datetime%dsec, julianDate, ierr, cmessage)
+  case default; ierr=20; message=trim(message)//trim(calendar)//': calendar invalid; accept either noleap, 365_day, standard, gregorian, or proleptic_gregorian'; return
+ end select
+ if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+ END SUBROUTINE conv_cal2julian
+
+END MODULE process_time_module

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -83,14 +83,12 @@ module public_var
   character(len=strLen),public    :: ancil_dir            = ''              ! directory containing ancillary data
   character(len=strLen),public    :: input_dir            = ''              ! directory containing input data
   character(len=strLen),public    :: output_dir           = ''              ! directory containing output data
+  character(len=strLen),public    :: restart_dir          = charMissing     ! directory for restart output (netCDF)
   ! RUN CONTROL
   character(len=strLen),public    :: case_name            = ''              ! name of simulation
   character(len=strLen),public    :: simStart             = ''              ! date string defining the start of the simulation
   character(len=strLen),public    :: simEnd               = ''              ! date string defining the end of the simulation
   character(len=strLen),public    :: newFileFrequency     = 'annual'        ! frequency for new output files (day, month, annual, single)
-  character(len=strLen),public    :: restart_write        = 'never'         ! restart write option: never-> N[n]ever write, L[l]ast -> write at last time step, S[s]pecified
-  character(len=strLen),public    :: restart_date         = charMissing     ! specifed restart date
-  character(len=strLen),public    :: fname_state_in       = charMissing     ! name of state file
   integer(i4b)         ,public    :: routOpt              = integerMissing  ! routing scheme options  0-> both, 1->IRF, 2->KWT, otherwise error
   integer(i4b)         ,public    :: doesBasinRoute       = 1               ! basin routing options   0-> no, 1->IRF, otherwise error
   integer(i4b)         ,public    :: doesAccumRunoff      = 1               ! option to delayed runoff accumulation over all the upstream reaches
@@ -128,6 +126,13 @@ module public_var
   character(len=strLen),public    :: vname_j_index        = ''              ! variable for numbers of x (longitude) index if runoff file is grid
   character(len=strLen),public    :: dname_hru_remap      = ''              ! dimension name for river network HRU
   character(len=strLen),public    :: dname_data_remap     = ''              ! dimension name for runoff HRU ID
+  ! RESTART OPTION
+  character(len=strLen),public    :: restart_write        = 'never'         ! restart write option: N[n]ever-> never write, L[l]ast -> write at last time step, S[s]pecified, Monthly, Daily
+  character(len=strLen),public    :: restart_date         = charMissing     ! specifed restart date
+  integer(i4b)         ,public    :: restart_month        = 1               ! restart periodic month. Default Jan (write every January of year)
+  integer(i4b)         ,public    :: restart_day          = 1               ! restart periodic day.   Default 1st (write every 1st of month)
+  integer(i4b)         ,public    :: restart_hour         = 0               ! restart periodic hour.  Default 0hr (write every 00 hr of day)
+  character(len=strLen),public    :: fname_state_in       = charMissing     ! name of state file
   ! SPATIAL CONSTANT PARAMETERS
   character(len=strLen),public    :: param_nml            = ''              ! name of the namelist file
   ! COMPUTATION OPTION

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -116,6 +116,7 @@ module public_var
   character(len=strLen),public    :: dname_ylat           = ''              ! dimension name for y (i, latitude) dimension
   character(len=strLen),public    :: units_qsim           = ''              ! units of simulated runoff data
   real(dp)             ,public    :: dt                   = realMissing     ! time step (seconds)
+  real(dp)             ,public    :: input_fillvalue      = realMissing     ! fillvalue used for input variables (runoff, precipitation, evaporation)
   ! RUNOFF REMAPPING
   logical(lgt),public             :: is_remap             = .false.         ! logical whether or not runnoff needs to be mapped to river network HRU
   character(len=strLen),public    :: fname_remap          = ''              ! runoff mapping netCDF name

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -137,6 +137,7 @@ CONTAINS
    case('<dname_ylat>');           dname_ylat   = trim(cData)                      ! name of y (i,lat) dimension
    case('<units_qsim>');           units_qsim   = trim(cData)                      ! units of runoff
    case('<dt_qsim>');              read(cData,*,iostat=io_error) dt                ! time interval of the gridded runoff
+   case('<input_fillvalue>');      read(cData,*,iostat=io_error) input_fillvalue   ! fillvalue used for input variable
    ! RUNOFF REMAPPING
    case('<is_remap>');             read(cData,*,iostat=io_error) is_remap          ! logical whether or not runnoff needs to be mapped to river network HRU
    case('<fname_remap>');          fname_remap          = trim(cData)              ! name of runoff mapping netCDF

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -104,14 +104,12 @@ CONTAINS
    case('<ancil_dir>');            ancil_dir   = trim(cData)                       ! directory containing ancillary data
    case('<input_dir>');            input_dir   = trim(cData)                       ! directory containing input data
    case('<output_dir>');           output_dir  = trim(cData)                       ! directory containing output data
+   case('<restart_dir>');          restart_dir = trim(cData)                       ! directory for restart output (netCDF)
    ! RUN CONTROL
    case('<case_name>');            case_name   = trim(cData)                       ! name of simulation. used as head of model output and restart file
    case('<sim_start>');            simStart    = trim(cData)                       ! date string defining the start of the simulation
    case('<sim_end>');              simEnd      = trim(cData)                       ! date string defining the end of the simulation
    case('<newFileFrequency>');     newFileFrequency = trim(cData)                  ! frequency for new output files (day, month, annual, single)
-   case('<restart_write>');        restart_write        = trim(cData)              ! restart write option: N[n]ever, L[l]ast
-   case('<restart_date>');         restart_date         = trim(cData)              ! specified restart date, yyyy-mm-dd (hh:mm:ss)
-   case('<fname_state_in>');       fname_state_in  = trim(cData)                   ! filename for the channel states
    case('<route_opt>');            read(cData,*,iostat=io_error) routOpt           ! routing scheme options  0-> both, 1->IRF, 2->KWT, otherwise error
    case('<doesBasinRoute>');       read(cData,*,iostat=io_error) doesBasinRoute    ! basin routing options   0-> no, 1->IRF, otherwise error
    case('<doesAccumRunoff>');      read(cData,*,iostat=io_error) doesAccumRunoff   ! option to delayed runoff accumulation over all the upstream reaches. 0->no, 1->yes
@@ -149,6 +147,13 @@ CONTAINS
    case('<vname_j_index>');        vname_j_index        = trim(cData)              ! name of variable containing index of ylat dimension in runoff grid (if runoff file is grid)
    case('<dname_hru_remap>');      dname_hru_remap      = trim(cData)              ! name of dimension of river network HRU ID
    case('<dname_data_remap>');     dname_data_remap     = trim(cData)              ! name of dimension of runoff HRU overlapping with river network HRU
+   ! RESTART
+   case('<restart_write>');        restart_write        = trim(cData)              ! restart write option: N[n]ever, L[l]ast, S[s]pecified, Monthly, Daily
+   case('<restart_date>');         restart_date         = trim(cData)              ! specified restart date, yyyy-mm-dd (hh:mm:ss) for Specified option
+   case('<restart_month>');        read(cData,*,iostat=io_error) restart_month     ! restart periodic month
+   case('<restart_day>');          read(cData,*,iostat=io_error) restart_day       ! restart periodic day
+   case('<restart_hour>');         read(cData,*,iostat=io_error) restart_hour      ! restart periodic hour
+   case('<fname_state_in>');       fname_state_in       = trim(cData)              ! filename for the channel states
    ! SPATIAL CONSTANT PARAMETERS
    case('<param_nml>');            param_nml       = trim(cData)                   ! name of namelist including routing parameter value
    ! USER OPTIONS: Define options to include/skip calculations
@@ -229,6 +234,11 @@ CONTAINS
   endif
 
  end do  ! looping through lines in the control file
+
+ ! ---------- directory option  ---------------------------------------------------------------------
+ if (trim(restart_dir)==charMissing) then
+   restart_dir = output_dir
+ endif
 
  ! ---------- control river network writing option  ---------------------------------------------------------------------
  ! Case1- river network subset mode (idSegOut>0):  Write the network variables read from file over only upstream network specified idSegOut

--- a/route/build/src/standalone/model_setup.f90
+++ b/route/build/src/standalone/model_setup.f90
@@ -81,7 +81,7 @@ CONTAINS
    ierr=0; message='init_data/'
 
    ! runoff input files initialization
-   call inFile_pop(ierr, message)
+   call inFile_pop(ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
    ! time initialization
@@ -165,6 +165,8 @@ CONTAINS
   USE public_var, ONLY: fname_qsim              ! simulated runoff txt file that includes the NetCDF file names
   USE public_var, ONLY: vname_time              ! variable name for time
   USE public_var, ONLY: dname_time              !
+  USE public_var, ONLY: time_units              !
+  USE public_var, ONLY: calendar                !
   USE globalData, ONLY: infileinfo_data         ! the information of the input files
 
   ! output: error control
@@ -213,14 +215,22 @@ CONTAINS
    infileinfo_data(iFile)%infilename = trim(filenameData)
 
    ! get the time units
-   call get_var_attr(trim(input_dir)//trim(infileinfo_data(iFile)%infilename), &
-                     trim(vname_time), 'units', infileinfo_data(iFile)%unit, ierr, cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+   if (trim(time_units) == charMissing) then
+     call get_var_attr(trim(input_dir)//trim(infileinfo_data(iFile)%infilename), &
+                       trim(vname_time), 'units', infileinfo_data(iFile)%unit, ierr, cmessage)
+     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+   else
+     infileinfo_data(iFile)%unit = trim(time_units)
+   end if
 
    ! get the calendar
-   call get_var_attr(trim(input_dir)//trim(infileinfo_data(iFile)%infilename), &
-                     trim(vname_time), 'calendar', infileinfo_data(iFile)%calendar, ierr, cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+   if (trim(calendar) == charMissing) then
+     call get_var_attr(trim(input_dir)//trim(infileinfo_data(iFile)%infilename), &
+                       trim(vname_time), 'calendar', infileinfo_data(iFile)%calendar, ierr, cmessage)
+     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+   else
+     infileinfo_data(iFile)%calendar = trim(calendar)
+   end if
 
    ! get the dimension of the time to populate nTime and pass it to the get_nc file
    call get_nc_dim_len(trim(input_dir)//trim(infileinfo_data(iFile)%infilename), &
@@ -278,9 +288,10 @@ CONTAINS
  SUBROUTINE init_time(ierr, message)  ! output
 
   ! subroutines:
-  USE process_time_module, ONLY: process_time   ! process time information
-  USE process_time_module, ONLY: process_calday ! compute data and time from julian day
-  USE io_netcdf,           ONLY: get_nc         ! netcdf input
+  USE process_time_module, ONLY: process_time    ! process time information
+  USE process_time_module, ONLY: conv_julian2cal ! compute data and time from julian day
+  USE process_time_module, ONLY: conv_cal2julian ! compute data and time from julian day
+  USE time_utils_module,   ONLY: ndays_month     ! compute number of days in a month
   ! derived datatype
   USE dataTypes,  ONLY: time                    ! time data type
   ! public data
@@ -288,8 +299,13 @@ CONTAINS
   USE public_var, ONLY: simStart                ! date string defining the start of the simulation
   USE public_var, ONLY: simEnd                  ! date string defining the end of the simulation
   USE public_var, ONLY: calendar                ! calendar name
+  USE public_var, ONLY: dt
+  USE public_var, ONLY: secprday
   USE public_var, ONLY: restart_write           ! restart write option
   USE public_var, ONLY: restart_date            ! restart date
+  USE public_var, ONLY: restart_month           ! periodic restart month
+  USE public_var, ONLY: restart_day             ! periodic restart day
+  USE public_var, ONLY: restart_hour            ! periodic restart hr
   ! saved time variables
   USE globalData, ONLY: timeVar                 ! time variables (unit given by runoff data)
   USE globalData, ONLY: iTime                   ! time index at simulation time step
@@ -298,8 +314,9 @@ CONTAINS
   USE globalData, ONLY: startJulday             ! julian day: start of routing simulation
   USE globalData, ONLY: endJulday               ! julian day: end of routing simulation
   USE globalData, ONLY: modJulday               ! julian day: at model time step
-  USE globalData, ONLY: restartJulday           ! julian day: at restart
   USE globalData, ONLY: modTime                 ! model time data (yyyy:mm:dd:hh:mm:ss)
+  USE globalData, ONLY: restCal                 ! restart time data (yyyy:mm:dd:hh:mm:sec)
+  USE globalData, ONLY: dropCal                 ! restart dropoff calendar date/time
   USE globalData, ONLY: infileinfo_data         ! the information of the input files
 
   implicit none
@@ -316,6 +333,9 @@ CONTAINS
   integer(i4b)                             :: iFile ! for loop over the nc files
   type(time)                               :: rofCal
   type(time)                               :: simCal
+  integer(i4b)                             :: nDays          ! number of days in a month
+  real(dp)                                 :: restartJulday
+  real(dp)                                 :: tempJulday
   character(len=strLen)                    :: cmessage         ! error message of downwind routine
   character(len=50)                        :: fmt1='(a,I4,a,I2.2,a,I2.2,x,I2.2,a,I2.2,a,F5.2)'
 
@@ -363,8 +383,8 @@ CONTAINS
 
   ! check sim_start is before the last time step in runoff data
   if(startJulday>roJulday(nTime)) then
-    call process_calday(roJulday(nTime), calendar, rofCal, ierr, cmessage)
-    call process_calday(startJulday, calendar, simCal, ierr, cmessage)
+    call conv_julian2cal(roJulday(nTime), calendar, rofCal, ierr, cmessage)
+    call conv_julian2cal(startJulday, calendar, simCal, ierr, cmessage)
     write(iulog,'(2a)') new_line('a'),'ERROR: <sim_start> is after the first time step in input runoff'
     write(iulog,fmt1)  ' runoff_end  : ', rofCal%iy,'-',rofCal%im,'-',rofCal%id, rofCal%ih,':', rofCal%imin,':',rofCal%dsec
     write(iulog,fmt1)  ' <sim_start> : ', simCal%iy,'-',simCal%im,'-',simCal%id, simCal%ih,':', simCal%imin,':',simCal%dsec
@@ -373,8 +393,8 @@ CONTAINS
 
   ! Compare sim_start vs. time at first time step in runoff data
   if (startJulday < roJulday(1)) then
-    call process_calday(roJulday(1), calendar, rofCal, ierr, cmessage)
-    call process_calday(startJulday, calendar, simCal, ierr, cmessage)
+    call conv_julian2cal(roJulday(1), calendar, rofCal, ierr, cmessage)
+    call conv_julian2cal(startJulday, calendar, simCal, ierr, cmessage)
     write(iulog,'(2a)') new_line('a'),'WARNING: <sim_start> is before the first time step in input runoff'
     write(iulog,fmt1)  ' runoff_start: ', rofCal%iy,'-',rofCal%im,'-',rofCal%id, rofCal%ih,':', rofCal%imin,':',rofCal%dsec
     write(iulog,fmt1)  ' <sim_start> : ', simCal%iy,'-',simCal%im,'-',simCal%id, simCal%ih,':', simCal%imin,':',simCal%dsec
@@ -384,8 +404,8 @@ CONTAINS
 
   ! Compare sim_end vs. time at last time step in runoff data
   if (endJulday > roJulday(nTime)) then
-    call process_calday(roJulday(nTime), calendar, rofCal, ierr, cmessage)
-    call process_calday(endJulday,       calendar, simCal, ierr, cmessage)
+    call conv_julian2cal(roJulday(nTime), calendar, rofCal, ierr, cmessage)
+    call conv_julian2cal(endJulday,       calendar, simCal, ierr, cmessage)
     write(iulog,'(2a)')  new_line('a'),'WARNING: <sim_end> is after the last time step in input runoff'
     write(iulog,fmt1)   ' runoff_end: ', rofCal%iy,'-',rofCal%im,'-',rofCal%id, rofCal%ih,':', rofCal%imin,':',rofCal%dsec
     write(iulog,fmt1)   ' <sim_end> : ', simCal%iy,'-',simCal%im,'-',simCal%id, simCal%ih,':', simCal%imin,':',simCal%dsec
@@ -404,25 +424,51 @@ CONTAINS
   ! initialize previous model time
   modTime(0) = time(integerMissing, integerMissing, integerMissing, integerMissing, integerMissing, realMissing)
 
-  ! restart drop off time
+ ! Set restart calendar date/time and dropoff calendar date/time and
+ ! -- For periodic restart options  ---------------------------------------------------------------------
+ ! Ensure that user-input restart month, day are valid.
+ ! "Annual" option:  if user input day exceed number of days given user input month, set to last day
+ ! "Monthly" option: use 2000-01 as template calendar yr/month
+ ! "Daily" option:   use 2000-01-01 as template calendar yr/month/day
+ select case(trim(restart_write))
+   case('Annual','annual')
+     call ndays_month(2000, restart_month, calendar, nDays, ierr, cmessage)
+     if(ierr/=0) then; message=trim(message)//trim(cmessage); return; endif
+     if (restart_day > nDays) restart_day=nDays
+   case('Monthly','monthly'); restart_month = 1
+   case('Daily','daily');     restart_month = 1; restart_day = 1
+ end select
+
   select case(trim(restart_write))
     case('last','Last')
-      call process_time(trim(simEnd), calendar, restartJulday, ierr, cmessage)
-      if(ierr/=0) then; message=trim(message)//trim(cmessage)//' [restartDate]'; return; endif
-    case('never','Never')
-      restartJulday = 0.0_dp
+      call conv_julian2cal(endJulday, calendar, dropCal, ierr, cmessage)
+      if(ierr/=0) then; message=trim(message)//trim(cmessage)//' [endJulday->dropCal]'; return; endif
+      restart_month = dropCal%im; restart_day = dropCal%id; restart_hour = dropCal%ih
     case('specified','Specified')
       if (trim(restart_date) == charMissing) then
         ierr=20; message=trim(message)//'<restart_date> must be provided when <restart_write> option is "specified"'; return
       end if
       call process_time(trim(restart_date),calendar, restartJulday, ierr, cmessage)
-      if(ierr/=0) then; message=trim(message)//trim(cmessage)//' [restartDate]'; return; endif
+      if(ierr/=0) then; message=trim(message)//trim(cmessage)//' [restart_date]'; return; endif
+      restartJulday = restartJulday - dt/secprday
+      call conv_julian2cal(restartJulday, calendar, dropCal, ierr, cmessage)
+      if(ierr/=0) then; message=trim(message)//trim(cmessage)//' [restartJulday->dropCal]'; return; endif
+      restart_month = dropCal%im; restart_day = dropCal%id; restart_hour = dropCal%ih
+    case('Annual','Monthly','Daily','annual','monthly','daily')
+      restCal = time(2000, restart_month, restart_day, restart_hour, 0, 0._dp)
+      call conv_cal2julian(restCal, calendar, tempJulday, ierr, cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [restCal->tempJulday]'; return; endif
+      tempJulday = tempJulday - dt/secprday
+      call conv_julian2cal(tempJulday, calendar, dropCal, ierr, cmessage)
+      if(ierr/=0) then; message=trim(message)//trim(cmessage)//' [tempJulday->dropCal]'; return; endif
+      restart_month = dropCal%im; restart_day = dropCal%id; restart_hour = dropCal%ih
+    case('never','Never')
+      restCal = time(integerMissing, integerMissing, integerMissing, integerMissing, integerMissing, realMissing)
     case default
-      ierr=20; message=trim(message)//'Current accepted <restart_write> options: last[Last], never[Never], specified[Specified]'; return
+      ierr=20; message=trim(message)//'Current accepted <restart_write> options: L[l]ast, N[n]ever, S[s]pecified, A[a]nnual, M[m]onthly, D[d]aily'; return
   end select
 
  END SUBROUTINE init_time
-
 
 
  ! *****
@@ -606,7 +652,7 @@ CONTAINS
 
  end do  ! looping through the vector
 
- ! check again
+ ! check
  do ix=1,size(qid)
   if(qix(ix) /= integerMissing)then
    if(qid(ix) /= qidMaster( qix(ix) ) )then

--- a/route/build/src/standalone/read_runoff.f90
+++ b/route/build/src/standalone/read_runoff.f90
@@ -6,9 +6,9 @@ USE public_var
 USE io_netcdf, only:open_nc
 USE io_netcdf, only:get_nc
 USE io_netcdf, only:get_var_attr
+USE io_netcdf, only:check_attr
 USE io_netcdf, only:get_nc_dim_len
 USE dataTypes, only:runoff                 ! runoff data type
-
 
 implicit none
 
@@ -248,7 +248,7 @@ contains
  ! local variables
  integer(i4b)                       :: iStart(2)
  integer(i4b)                       :: iCount(2)
- real(dp)                           :: fill_value         ! fill_value
+ logical(lgt)                       :: existFillVal
  real(dp)                           :: dummy(nSpace,1)    ! data read
  character(len=strLen)              :: cmessage           ! error message from subroutine
 
@@ -261,12 +261,15 @@ contains
  call get_nc(fname, var_name, dummy, iStart, iCount, ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- ! get the _fill_values for runoff variable
- call get_var_attr(trim(fname), trim(var_name), '_FillValue', fill_value, ierr, cmessage)
- if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ ! get the _fill_values for runoff variable if exist
+ existFillVal = check_attr(fname, var_name, '_FillValue')
+ if (existFillval) then
+   call get_var_attr(fname, var_name, '_FillValue', input_fillvalue, ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ end if
 
  ! replace _fill_value with -999 for dummy
- where ( abs(dummy - fill_value) < verySmall ) dummy = realMissing
+ where ( abs(dummy - input_fillvalue) < verySmall ) dummy = realMissing
 
  ! reshape
  runoff_data_in%sim(1:nSpace) = dummy(1:nSpace,1)
@@ -294,9 +297,9 @@ contains
  integer(i4b), intent(out)   :: ierr             ! error code
  character(*), intent(out)   :: message          ! error message
  ! local variables
+ logical(lgt)                :: existFillVal
  integer(i4b)                :: iStart(3)
  integer(i4b)                :: iCount(3)
- real(dp)                    :: fill_value                   ! fill_value
  real(dp)                    :: dummy(nSpace(2),nSpace(1),1) ! data read
  character(len=strLen)       :: cmessage                     ! error message from subroutine
 
@@ -310,11 +313,14 @@ contains
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  ! get the _fill_values for runoff variable
- call get_var_attr(trim(fname), trim(var_name), '_FillValue', fill_value, ierr, cmessage)
- if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ existFillVal = check_attr(fname, var_name, '_FillValue')
+ if (existFillval) then
+   call get_var_attr(fname, var_name, '_FillValue', input_fillvalue, ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ end if
 
  ! replace _fill_value with -999 for dummy
- where ( abs(dummy - fill_value) < verySmall ) dummy = realMissing
+ where ( abs(dummy - input_fillvalue) < verySmall ) dummy = realMissing
 
  ! reshape
  runoff_data_in%sim2d(1:nSpace(2),1:nSpace(1)) = dummy(1:nSpace(2),1:nSpace(1),1)

--- a/route/build/src/standalone/route_runoff.f90
+++ b/route/build/src/standalone/route_runoff.f90
@@ -32,7 +32,7 @@ USE mpi_routine,         ONLY: mpi_route        ! Distribute runoff to proc, rou
 USE get_runoff,          ONLY: get_hru_runoff   !
 USE write_simoutput_pio, ONLY: prep_output      !
 USE write_simoutput_pio, ONLY: output           !
-USE write_restart_pio,   ONLY: output_state     ! write netcdf state output file
+USE write_restart_pio,   ONLY: main_restart     ! write netcdf state output file
 
 implicit none
 
@@ -100,7 +100,7 @@ do while (.not.finished)
   if(ierr/=0) call handle_err(ierr, cmessage)
   call t_stopf ('output')
 
-  call output_state(ierr, cmessage)
+  call main_restart(ierr, cmessage)
   if(ierr/=0) call handle_err(ierr, cmessage)
 
   call update_time(finished, ierr, cmessage)

--- a/route/build/src/time_utils.f90
+++ b/route/build/src/time_utils.f90
@@ -27,6 +27,8 @@ USE public_var, ONLY: secprday,secprhour,secprmin, &   ! seconds in an (day, hou
 implicit none
 private
 public::extractTime
+public::ndays_month
+public::isLeapYear
 public::compjulday
 public::compjulday_noleap
 public::compcalday
@@ -35,6 +37,75 @@ public::elapsedSec
 
 contains
 
+ ! ******************************************************************************************
+ ! public function: check leap year or not
+ ! ******************************************************************************************
+ logical(lgt) function isLeapYear(yr)
+ implicit none
+ integer(i4b), intent(in)  :: yr
+ if (mod(yr, 4) == 0) then
+   if (mod(yr, 100) == 0) then
+     if (mod(yr, 400) == 0) then
+       isLeapYear = .True.
+     else
+       isLeapYear = .False.
+     end if
+   else
+     isLeapYear = .True.
+   end if
+ else
+   isLeapYear = .False.
+ end if
+ end function isLeapYear
+
+ ! ******************************************************************************************
+ ! public subroutine: get number of days within a month
+ ! ******************************************************************************************
+ subroutine ndays_month(yr, mo, calendar, ndays, ierr, message)
+ implicit none
+ ! input
+ integer(i4b),intent(in)           :: yr
+ integer(i4b),intent(in)           :: mo
+ character(*),intent(in)           :: calendar
+ ! output
+ integer(i4b)         ,intent(out) :: ndays     !
+ integer(i4b),         intent(out) :: ierr         ! error code
+ character(len=strLen),intent(out) :: message     ! error message
+ ! local variables
+ integer(i4b)                      :: yr_next, mo_next
+ real(dp)                          :: julday1, julday2
+ character(len=strLen)             :: cmessage          ! error message of downwind routine
+
+ ierr=0; message="ndays_month/"
+
+ select case(trim(calendar))
+   case ('standard','gregorian','proleptic_gregorian')
+     call compjulday(yr,mo,1,0,0,0._dp,julday1,ierr,cmessage)
+   case('noleap')
+     call compjulday_noleap(yr,mo,1,0,0,0._dp,julday1,ierr,cmessage)
+   case default; ierr=20; message=trim(message)//'calendar name: '//trim(calendar)//' invalid'; return
+ end select
+ if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+ if (mo == 12) then
+   mo_next = 1
+   yr_next = yr+1
+ else
+   yr_next = yr
+   mo_next = mo+1
+ end if
+ select case(trim(calendar))
+   case ('standard','gregorian','proleptic_gregorian')
+     call compjulday(yr_next,mo_next,1,0,0,0._dp,julday2,ierr,cmessage)
+   case('noleap')
+     call compjulday_noleap(yr_next,mo_next,1,0,0,0._dp,julday2,ierr,cmessage)
+   case default; ierr=20; message=trim(message)//'calendar name: '//trim(calendar)//' invalid'; return
+ end select
+ if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+ ndays = nint(julday2-julday1)
+
+ end subroutine ndays_month
 
  ! ******************************************************************************************
  ! public subroutine extractTime: extract year/month/day/hour/minute/second from units string


### PR DESCRIPTION
1. Added more restart dropoff timing options - periodic restart dropoff.
- Annual. drop off every year at a particular month/day/hr specified with `restart_month`, `restart_day`, `restart_hour`.
- Monthly. drop off every month at a particular day/hr specified with `restart_day`, `restart_hour`.
- Daily. drop off every day at a particular hour specified with `restart_hour`.

Also, user need to specify _desired restart timing_ instead of restart dropoff timing in `restart_write` option - `specified`, `Annual`, `Monthly`, `Daily`

2. Re-organized restart write module, using more subroutines.

3. Added and used new/modified time utility routines through the codes.  

4. Need to change order of compilation of modules so that objects are properly linked.