### PR TITLE
Feature/mpi pio

### DIFF
--- a/route/build/src/irf_route.f90
+++ b/route/build/src/irf_route.f90
@@ -200,6 +200,8 @@ CONTAINS
 
   ! take out the water from the reach if the wm flag is true and the value are not missing
   ! here we should make sure the real missing is not injection (or negative abstration)
+  abstract_actual = 0._dp ! this can be removed later (after extensive testing)
+  init_STRQ = 0._dp ! this can be removed later (after extensive testing)
   if((RCHFLX_out(iens,segIndex)%REACH_WM_FLUX /= realMissing).and.(is_flux_wm)) then
     abstract_actual = RCHFLX_out(iens,segIndex)%REACH_Q_IRF ! get the reach streamflow as actual abstration
     init_STRQ = RCHFLX_out(iens,segIndex)%REACH_Q_IRF ! TO BE DELETED


### PR DESCRIPTION
very minor change in irf_route to initialize the actual abstract and initial calculated IRF. This was creating error when running the CLM with HDMA (although the code was compiled successfully)
These lines (and the water balance) can be removed after extensive test of lakes with abstraction and injection.