### PR TITLE
runoff fillvalue issue

### DIFF
--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -94,6 +94,7 @@ module public_var
   character(len=strLen),public    :: units_qsim           = ''              ! units of simulated runoff data
   real(dp)             ,public    :: dt                   = realMissing     ! time step (seconds)
   real(dp)             ,public    :: ro_fillvalue         = realMissing     ! fillvalue used for runoff depth variable
+  logical(lgt)         ,public    :: userRunoffFillvalue  = .false.         ! true -> runoff depth fillvalue used in netcdf is specified here, otherwise -> false
   ! RUNOFF REMAPPING
   logical(lgt),public             :: is_remap             = .false.         ! logical whether or not runnoff needs to be mapped to river network HRU
   character(len=strLen),public    :: fname_remap          = ''              ! runoff mapping netCDF name

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -121,7 +121,9 @@ contains
    case('<dname_ylat>');           dname_ylat   = trim(cData)                      ! name of y (i,lat) dimension
    case('<units_qsim>');           units_qsim   = trim(cData)                      ! units of runoff
    case('<dt_qsim>');              read(cData,*,iostat=io_error) dt                ! time interval of the gridded runoff
-   case('<ro_fillvalue>');         read(cData,*,iostat=io_error) ro_fillvalue      ! fillvalue used for runoff depth variable
+   case('<ro_fillvalue>')
+                                   read(cData,*,iostat=io_error) ro_fillvalue      ! fillvalue used for runoff depth variable
+                                   userRunoffFillvalue = .true.                    ! true -> runoff depth fillvalue used in netcdf is specified here, otherwise -> false
    ! RUNOFF REMAPPING
    case('<is_remap>');             read(cData,*,iostat=io_error) is_remap          ! logical whether or not runnoff needs to be mapped to river network HRU
    case('<fname_remap>');          fname_remap          = trim(cData)              ! name of runoff mapping netCDF

--- a/route/build/src/read_runoff.f90
+++ b/route/build/src/read_runoff.f90
@@ -92,6 +92,7 @@ contains
  integer(i4b), intent(out)               :: ierr            ! error code
  character(*), intent(out)               :: message         ! error message
  ! local variables
+ logical(lgt)                            :: existFillVal
  character(len=strLen)                   :: cmessage        ! error message from subroutine
 
  ierr=0; message='read_1D_runoff_metadata/'
@@ -116,6 +117,18 @@ contains
  if (trim(calendar) == charMissing) then
    call get_var_attr(ncidRunoff, trim(vname_time), 'calendar', calendar, ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ end if
+
+ ! get the _fill_values for runoff variable
+ if (.not.userRunoffFillvalue) then
+   existFillVal = check_attr(ncidRunoff, vname_qsim, '_FillValue')
+   if (existFillVal) then
+     call get_var_attr(ncidRunoff, vname_qsim, '_FillValue', ro_fillvalue, ierr, cmessage)
+     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+   else
+     write(iulog,'(a)')        'WARNING: User did not provide runoff fillvalue in control file nor runoff netcdf does not have fillvalue in attribute.'
+     write(iulog,'(a,x,F8.1)') '         Default missing values used is', ro_fillvalue
+   end if
  end if
 
  ! allocate space for hru_id
@@ -151,6 +164,7 @@ contains
  integer(i4b), intent(out)               :: ierr            ! error code
  character(*), intent(out)               :: message         ! error message
  ! local variables
+ logical(lgt)                            :: existFillVal
  character(len=strLen)                   :: cmessage        ! error message from subroutine
  ! initialize error control
  ierr=0; message='read_2D_runoff_metadata/'
@@ -169,6 +183,18 @@ contains
  if (trim(calendar) == charMissing) then
    call get_var_attr(ncidRunoff, trim(vname_time), 'calendar', calendar, ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ end if
+
+ ! get the _fill_values for runoff variable
+ if (.not.userRunoffFillvalue) then
+   existFillVal = check_attr(ncidRunoff, vname_qsim, '_FillValue')
+   if (existFillVal) then
+     call get_var_attr(ncidRunoff, vname_qsim, '_FillValue', ro_fillvalue, ierr, cmessage)
+     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+   else
+     write(iulog,'(a)')        'WARNING: User did not provide runoff fillvalue in control file nor runoff netcdf does not have fillvalue attribute.'
+     write(iulog,'(a,x,F8.1)') '         Default missing values used is', ro_fillvalue
+   end if
  end if
 
  ! get size of ylat dimension
@@ -245,7 +271,6 @@ contains
  ! local variables
  integer(i4b)                  :: iStart(2)
  integer(i4b)                  :: iCount(2)
- logical(lgt)                  :: existFillVal
  real(dp)                      :: dummy(nSpace,1)    ! data read
  character(len=strLen)         :: cmessage           ! error message from subroutine
 
@@ -261,13 +286,6 @@ contains
  iCount = [nSpace,1]
  call get_nc(ncidRunoff, vname_qsim, dummy, iStart, iCount, ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
- ! get the _fill_values for runoff variable if exist
- existFillVal = check_attr(ncidRunoff, vname_qsim, '_FillValue')
- if (existFillval) then
-   call get_var_attr(ncidRunoff, vname_qsim, '_FillValue', ro_fillvalue, ierr, cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
- end if
 
  ! replace _fill_value with -999 for dummy
  where ( abs(dummy - ro_fillvalue) < verySmall ) dummy = realMissing
@@ -296,7 +314,6 @@ contains
  integer(i4b), intent(out)   :: ierr             ! error code
  character(*), intent(out)   :: message          ! error message
  ! local variables
- logical(lgt)                :: existFillVal
  integer(i4b)                :: iStart(3)
  integer(i4b)                :: iCount(3)
  real(dp)                    :: dummy(nSpace(2),nSpace(1),1) ! data read
@@ -313,13 +330,6 @@ contains
  iCount = [nSpace(2),nSpace(1),1]
  call get_nc(ncidRunoff, vname_qsim, dummy, iStart, iCount, ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
- ! get the _fill_values for runoff variable
- existFillVal = check_attr(ncidRunoff, vname_qsim, '_FillValue')
- if (existFillval) then
-   call get_var_attr(ncidRunoff, vname_qsim, '_FillValue', ro_fillvalue, ierr, cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
- end if
 
  ! replace _fill_value with -999. for dummy
  where ( abs(dummy - ro_fillvalue) < verySmall ) dummy = realMissing


### PR DESCRIPTION
This change fixed the issue below.
 
- A user was not able to overwrite runoff fillvalue if runoff netcdf has fillvalue attribute. This would be problem if runoff netcdf has wrong fillvalue; e.g., runoff netcdf is an output of xarray which puts NaN in fillvalue attribute as default. 

- Avoid checking/reading fillvalue every time step. Instead, runoff fillvalue is read and saved during model setup