### PR TITLE
small refactoring history file output module

### DIFF
--- a/route/build/src/standalone/route_runoff.f90
+++ b/route/build/src/standalone/route_runoff.f90
@@ -30,7 +30,7 @@ USE model_utils,         ONLY: handle_err
 USE mpi_routine,         ONLY: mpi_route        ! Distribute runoff to proc, route them, and gather,
 ! subroutines: model I/O
 USE get_runoff,          ONLY: get_hru_runoff   !
-USE write_simoutput_pio, ONLY: prep_output      !
+USE write_simoutput_pio, ONLY: main_new_file    !
 USE write_simoutput_pio, ONLY: output           !
 USE write_restart_pio,   ONLY: main_restart     ! write netcdf state output file
 
@@ -80,7 +80,7 @@ if(ierr/=0) call handle_err(ierr, cmessage)
 ! ***********************************
 do while (.not.finished)
 
-  call prep_output(ierr, cmessage)
+  call main_new_file(ierr, cmessage)
   if(ierr/=0) call handle_err(ierr, cmessage)
 
   if(pid==0)then


### PR DESCRIPTION
New structures:
- alarm to tell whether a new history file is generated and use for output (private routine: new_file_alarm)
- define new history file (public routine: prep_output) 
- Routine to wrap the above two (public routine: main_new_file)
- write out the variables in history file (public routine: output) 