### PR TITLE
Simplifying way of handling total upstream inflow information in irf

### DIFF
--- a/route/build/src/irf_route.f90
+++ b/route/build/src/irf_route.f90
@@ -15,8 +15,8 @@ USE public_var,        ONLY: integerMissing    ! missing value for integer numbe
 USE perf_mod,          ONLY: t_startf,t_stopf  ! timing start/stop
 USE lake_route_module, ONLY: lake_route        ! lake route module
 
-! privary
 implicit none
+
 private
 
 public::irf_route
@@ -46,7 +46,7 @@ CONTAINS
  type(subbasin_omp), intent(in),    allocatable  :: river_basin(:)      ! river basin information (mainstem, tributary outlet etc.)
  integer(i4b),       intent(in)                  :: ixDesire            ! index of the reach for verbose output ! Output
  type(RCHTOPO),      intent(in),    allocatable  :: NETOPO_in(:)        ! River Network topology
- type(RCHPRP),       intent(in),    allocatable  :: RPARAM_in(:)        ! River Network parameters
+ type(RCHPRP),       intent(in),    allocatable  :: RPARAM_in(:)        ! River reach parameters
  ! inout
  TYPE(STRFLX),       intent(inout), allocatable  :: RCHFLX_out(:,:)     ! Reach fluxes (ensembles, space [reaches]) for decomposed domains
  ! output variables
@@ -153,19 +153,21 @@ CONTAINS
  integer(i4b), intent(out)                :: ierr           ! error code
  character(*), intent(out)                :: message        ! error message
  ! Local variables to
- type(STRFLX), allocatable                :: uprflux(:)     ! upstream Reach fluxes
+ real(dp)                                 :: q_upstream     ! total discharge at top of the reach being processed
  real(dp)                                 :: abstract_actual! actual abstraction TO BE DELETED
  real(dp)                                 :: WB_check       ! water balance TO BE DELETED
  real(dp)                                 :: init_STRQ      ! init TO BE DELETED
- INTEGER(I4B)                             :: nUps           ! number of upstream segment
- INTEGER(I4B)                             :: iUps           ! upstream reach index
- INTEGER(I4B)                             :: iRch_ups       ! index of upstream reach in NETOPO
- INTEGER(I4B)                             :: ntdh           ! number of time steps in IRF
+ integer(i4b)                             :: nUps           ! number of upstream segment
+ integer(i4b)                             :: iUps           ! upstream reach index
+ integer(i4b)                             :: iRch_ups       ! index of upstream reach in NETOPO
+ integer(i4b)                             :: ntdh           ! number of time steps in IRF
+ integer(i4b)                             :: itdh           ! loop index for unit hydrograph
+ character(len=strLen)                    :: fmt1           ! format string
  character(len=strLen)                    :: cmessage       ! error message from subroutine
 
  ierr=0; message='segment_irf/'
 
- ! route streamflow through the river network
+ ! initialize future discharge array at first time
   if (.not.allocated(RCHFLX_out(iens,segIndex)%QFUTURE_IRF))then
 
    ntdh = size(NETOPO_in(segIndex)%UH)
@@ -177,35 +179,25 @@ CONTAINS
 
   end if
 
-  ! identify number of upstream segments of the reach being processed
+  ! get discharge coming from upstream
   nUps = size(NETOPO_in(segIndex)%UREACHI)
-
-  allocate(uprflux(nUps), stat=ierr, errmsg=cmessage)
-  if(ierr/=0)then; message=trim(message)//trim(cmessage)//': uprflux'; return; endif
-
+  q_upstream = 0.0_dp
   if (nUps>0) then
     do iUps = 1,nUps
       iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
-      uprflux(iUps) = RCHFLX_out(iens,iRch_ups)
+      q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%REACH_Q_IRF
     end do
   endif
 
-  ! perform river network UH routing
+  ! perform UH convolution
   call conv_upsbas_qr(NETOPO_in(segIndex)%UH,    &    ! input: reach unit hydrograph
-                      uprflux,                   &    ! input: upstream reach fluxes
+                      q_upstream,                &    ! input: total discharge at top of the reach being processed
                       RCHFLX_out(iens,segIndex), &    ! inout: updated fluxes at reach
                       ierr, message)                  ! output: error control
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
   ! Check True since now this reach now routed
   RCHFLX_out(iEns,segIndex)%isRoute=.True.
-
-  ! check
-  if(NETOPO_in(segIndex)%REACHIX == ixDesire)then
-   write(iulog,*) 'RCHFLX_out(iens,segIndex)%BASIN_QR(1),RCHFLX_out(iens,segIndex)%REACH_Q_IRF = ', &
-                   RCHFLX_out(iens,segIndex)%BASIN_QR(1),RCHFLX_out(iens,segIndex)%REACH_Q_IRF
-  endif
-
 
   ! take out the water from the reach if the wm flag is true and the value are not missing
   ! here we should make sure the real missing is not injection (or negative abstration)
@@ -225,6 +217,19 @@ CONTAINS
 
   WB_check = RCHFLX_out(iens,segIndex)%REACH_Q_IRF + abstract_actual - init_STRQ
 
+  ! check
+  if(segIndex==ixDesire)then
+    ntdh = size(NETOPO_in(segIndex)%UH)
+    write(fmt1,'(A,I5,A)') '(A, 1X',ntdh,'(1X,F20.7))'
+    write(*,'(2a)') new_line('a'),'** Check Impulse Response Function routing **'
+    write(*,'(a,x,I10,x,I10)') ' Reach index & ID       =', segIndex, NETOPO_in(segIndex)%REACHID
+    write(*,fmt1)              ' Unit-Hydrograph        =', (NETOPO_in(segIndex)%UH(itdh), itdh=1,ntdh)
+    write(*,'(a)')             ' * total discharge from upstream(q_upstream) [m3/s], local area discharge [m3/s], and Final discharge [m3/s]:'
+    write(*,'(a,x,F15.7)')     ' q_upstream             =', q_upstream
+    write(*,'(a,x,F15.7)')     ' RCHFLX_out%BASIN_QR(1) =', RCHFLX_out(iens,segIndex)%BASIN_QR(1)
+    write(*,'(a,x,F15.7)')     ' RCHFLX_out%REACH_Q_IRF =', RCHFLX_out(iens,segIndex)%REACH_Q_IRF
+  endif
+
  end subroutine segment_irf
 
 
@@ -232,41 +237,30 @@ CONTAINS
  ! subroutine: Compute delayed runoff from the upstream segments
  ! *********************************************************************
  subroutine conv_upsbas_qr(reach_uh,   &    ! input: reach unit hydrograph
-                           rflux_ups,  &    ! input: upstream reach fluxes
+                           q_upstream, &    ! input:
                            rflux,      &    ! input: input flux at reach
                            ierr, message)   ! output: error control
  ! ----------------------------------------------------------------------------------------
  ! Details: Convolute runoff volume of upstream at one reach at one time step
  ! ----------------------------------------------------------------------------------------
+
  USE public_var, ONLY: dt
+
  implicit none
  ! Input
  real(dp),     intent(in)               :: reach_uh(:)  ! reach unit hydrograph
- type(STRFLX), intent(in)               :: rflux_ups(:) ! upstream Reach fluxes
+ real(dp),     intent(in)               :: q_upstream   ! total discharge at top of the reach being processed
  ! inout
  type(STRFLX), intent(inout)            :: rflux        ! current Reach fluxes
  ! Output
  integer(i4b), intent(out)              :: ierr         ! error code
  character(*), intent(out)              :: message      ! error message
  ! Local variables to
- real(dp)                               :: q_upstream   ! total discharge at top of the reach being processed
- INTEGER(I4B)                           :: nTDH         ! number of UH data
- INTEGER(I4B)                           :: iTDH         ! index of UH data (i.e.,future time step)
- INTEGER(I4B)                           :: nUps         ! number of all upstream segment
- INTEGER(I4B)                           :: iUps         ! loop indices for u/s reaches
+ integer(i4b)                           :: nTDH         ! number of UH data
+ integer(i4b)                           :: iTDH         ! index of UH data (i.e.,future time step)
 
  ierr=0; message='conv_upsbas_qr/'
 
- ! identify number of upstream segments of the reach being processed
- nUps = size(rflux_ups)
-
- ! Find out total q at top of a segment
- q_upstream = 0.0_dp
- if(nUps>0)then
-   do iUps = 1,nUps
-     q_upstream = q_upstream + rflux_ups(iUps)%REACH_Q_IRF
-   end do
- endif
 
  ! place a fraction of runoff in future time steps
  nTDH = size(reach_uh) ! identify the number of future time steps of UH for a given segment
@@ -275,21 +269,18 @@ CONTAINS
                              + reach_uh(iTDH)*q_upstream
  enddo
 
- ! Volume stored in reach
+ ! compute volume in reach
  rflux%REACH_VOL(0) = rflux%REACH_VOL(1)
  rflux%REACH_VOL(1) = rflux%REACH_VOL(0) - (rflux%QFUTURE_IRF(1) - q_upstream)*dt
 
- ! Add local routed flow
+ ! Add local routed flow at the bottom of reach
  rflux%REACH_Q_IRF = rflux%QFUTURE_IRF(1) + rflux%BASIN_QR(1)
 
  ! move array back   use eoshift
- !rflux%QFUTURE_IRF=eoshift(rflux%QFUTURE_IRF,shift=1)
+ rflux%QFUTURE_IRF=eoshift(rflux%QFUTURE_IRF,shift=1)
 
- do itdh=2,ntdh
-  rflux%QFUTURE_IRF(itdh-1) = rflux%QFUTURE_IRF(itdh)
- enddo
 
- rflux%QFUTURE_IRF(ntdh) = 0._dp
+ rflux%QFUTURE_IRF(nTDH) = 0._dp
 
  end subroutine conv_upsbas_qr
 


### PR DESCRIPTION
Previous:

1. memory allocation for the whole flux datatype for upstream reaches.
2. pass the upstream datatype to convolution routine.
3. compute total inflow from upstreams in convolution routine.

New:
1.  compute total inflow from upstreams first.
2. pass total inflow to convolution routine.

This might improve performance using ifort optimized compilation.