### PR TITLE
revise Gamma distribution in develop branch

### DIFF
--- a/route/build/src/process_param.f90
+++ b/route/build/src/process_param.f90
@@ -35,13 +35,12 @@ contains
   IMPLICIT NONE
   ! input
   REAL(DP), INTENT(IN)                   :: dt          ! model time step
-  REAL(DP), INTENT(IN)                   :: fshape      ! shapef parameter in gamma distribution
-  REAL(DP), INTENT(IN)                   :: tscale      ! time scale parameter
+  REAL(DP), INTENT(IN)                   :: fshape      ! shape parameter in gamma distribution
+  REAL(DP), INTENT(IN)                   :: tscale      ! time scale parameter in gamma distribution
   ! output
   INTEGER(I4B), INTENT(OUT)              :: IERR        ! error code
   CHARACTER(*), INTENT(OUT)              :: MESSAGE     ! error message
   ! locals
-  REAL(DP)                               :: alamb       ! scale parameter
   REAL(DP)                               :: ntdh_min    ! minimum number of time delay points
   REAL(DP)                               :: ntdh_max    ! maximum number of time delay points
   REAL(DP)                               :: ntdh_try    ! trial number of time delay points
@@ -57,10 +56,9 @@ contains
   ! initialize error control
   ierr=0; message='basinUH/'
   ! use a Gamma distribution with shape parameter, fshape, and time parameter, tscale, input
-  alamb = fshape/tscale                  ! scale parameter
   ! find the desired number of future time steps
   ! check if the cummulative Gamma distribution is close to 1.00 for given model time step, tscale and fsahpe.
-  X_VALUE = alamb*dt
+  X_VALUE = dt/tscale 
   cumprob = gammp(fshape, X_VALUE)
   if(cumprob > 0.999_dp) then
    !print*, cumprob, X_VALUE
@@ -70,7 +68,7 @@ contains
    ntdh_max = 1000._dp
    ntdh_try = 0.5_dp*(ntdh_min + ntdh_max)
    do itry=1,maxtry
-    x_value = alamb*dt*ntdh_try
+    x_value = dt*ntdh_try/tscale
     cumprob = gammp(fshape, x_value)
     !print*, tscale, ntdh_try, cumprob, x_value, itry
     if(cumprob < 0.99_dp)  ntdh_min = ntdh_try
@@ -91,7 +89,7 @@ contains
   PSAVE = 0.                                                 ! cumulative probability at JTIM-1
   DO JTIM=1,NTDH
    TFUTURE            = REAL(JTIM, kind(dp))*DT       ! future time
-   CUMPROB            = gammp(fshape,alamb*TFUTURE)   ! cumulative probability at JTIM
+   CUMPROB            = gammp(fshape,TFUTURE/tscale)   ! cumulative probability at JTIM
    FRAC_FUTURE(JTIM)  = MAX(0._DP, CUMPROB-PSAVE)     ! probability between JTIM-1 and JTIM
    PSAVE              = CUMPROB                       ! cumulative probability at JTIM-1
    !WRITE(*,'(I5,1X,F20.5,1X,2(F11.5))') JTIM, TFUTURE, FRAC_FUTURE(JTIM), CUMPROB


### PR DESCRIPTION
The previous code ACTUALLY has an error in calculating the x_value of the Gamma distribution. The reason behind is that, when x_value is employed in "cumprob = gammp(fshape, x_value)", the gammp function requires the x_value being standardized. Given the two-parameter Gamma distribution, the time delay "dt* ntdh_try" should be standardized by "dt* ntdh_try/scale". The old mizuRoute code has an error in doing the standardization. Here this issue is fixed by removing variable "alamb" and updating variable "x_value".

Firstly, the figures below show the sensitivity of the updated Gamma distribution to the parameters GammaShape and GammaScale, respectively.
![shape_sensitivity](https://user-images.githubusercontent.com/48458815/122959160-3ece3080-d340-11eb-9e2c-59b2e33f0709.png)
![scale_sensitivity](https://user-images.githubusercontent.com/48458815/122959206-4097f400-d340-11eb-90e3-89cfd865db1e.png)

Secondly, the figures below show the impacts of code changes on routed runoff. This simulation is based on the Bow at Banff case study. The first figure shows the summa averageRoutedRunoff of the 1st GRU. The second figure shows the mizuRoute IRFroutedRunoff at the basin outlet. You can see that new code brings down the peak runoff. It is worth noting that this simulation runs hillslope in summa and thus investigates the code changes of summa. Given the similarity of hillslope routing in summa and mizuroute, I think the code change effects shown in summa also apply to mizuRoute.
![SUMMA_output](https://user-images.githubusercontent.com/48458815/122961498-af298180-d341-11eb-8d07-aad8a099e13b.png)
![mizuRoute_output](https://user-images.githubusercontent.com/48458815/122961506-b2247200-d341-11eb-8c43-28dd0db75a38.png)

The last but not least, the comparison between code output and analytical results. One thing I want to highlight is that the code error exists in standardizing x_value, not calculating cumprob. Therefore, when testing the differences, we should look at the x_value changes, not cumprob correctness (cumprob will be always correct once the shape parameter and a standardized x are given). The comparison of x_value is shown in the attached Excel file. Moreover, if you have interest looking at cumprob result, the attachment also shows that the code output cumprob matches the analytical result. Hope this helps :) 
[Gamma_dist_compare.xlsx](https://github.com/NCAR/mizuRoute/files/6695846/Gamma_dist_compare.xlsx)

