### PR TITLE
Develop bugfix restart

### DIFF
--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -50,6 +50,7 @@ module globalData
   USE var_lookup, only : nVarsPFAF     ! number of variables for data structure
   USE var_lookup, only : nVarsRFLX     ! number of variables for data structure
   USE var_lookup, only : nVarsIRFbas   ! number of variables for data structure
+  USE var_lookup, only : nVarsBasinQ   ! number of variables for data structure
   USE var_lookup, only : nVarsIRF      ! number of variables for data structure
   USE var_lookup, only : nVarsKWT      ! number of variables for data structure
 
@@ -91,6 +92,7 @@ module globalData
   type(var_info)                 , public :: meta_PFAF   (nVarsPFAF   ) ! pfafstetter code
   type(meta_var)                 , public :: meta_rflx   (nVarsRFLX   ) ! reach flux variables
   type(meta_var)                 , public :: meta_irf_bas(nVarsIRFbas ) ! basin IRF routing fluxes/states
+  type(meta_var)                 , public :: meta_basinQ (nVarsBasinQ ) ! reach inflow from basin
   type(meta_var)                 , public :: meta_kwt    (nVarsKWT    ) ! KWT routing fluxes/states
   type(meta_var)                 , public :: meta_irf    (nVarsIRF    ) ! IRF routing fluxes/states
 

--- a/route/build/src/popMetadat.f90
+++ b/route/build/src/popMetadat.f90
@@ -29,7 +29,8 @@ USE globalData, only : meta_NTOPO     ! network topology
 USE globalData, only : meta_PFAF      ! pfafstetter code
 
 USE globalData, only : meta_rflx      ! reach flux variables
-USE globalData, only : meta_irf_bas   ! within-basin irf routing fluxes and states
+USE globalData, only : meta_irf_bas   ! within-basin irf routing future flow
+USE globalData, only : meta_basinQ    ! reach inflow from basin
 USE globalData, only : meta_irf       ! irf routing fluxes and states in a segment
 USE globalData, only : meta_kwt       ! kinematic wave routing fluxes and states in a segment
 
@@ -44,10 +45,11 @@ USE var_lookup, only : ixSEG      , nVarsSEG      ! index of variables for data 
 USE var_lookup, only : ixNTOPO    , nVarsNTOPO    ! index of variables for data structure
 USE var_lookup, only : ixPFAF     , nVarsPFAF     ! index of variables for data structure
 
-USE var_lookup, only : ixRFLX     , nVarsRFLX     ! index of variables for data structure
-USE var_lookup, only : ixKWT      , nVarsKWT      ! index of variables for data structure
-USE var_lookup, only : ixIRF      , nVarsIRF      ! index of variables for data structure
-USE var_lookup, only : ixIRFbas   , nVarsIRFbas   ! index of variables for data structure
+USE var_lookup, only : ixRFLX                     ! index of variables for data structure
+USE var_lookup, only : ixKWT                      ! index of variables for data structure
+USE var_lookup, only : ixIRF                      ! index of variables for data structure
+USE var_lookup, only : ixIRFbas                   ! index of variables for data structure
+USE var_lookup, only : ixBasinQ                   ! index of variables for data structure
 
 implicit none
 
@@ -154,20 +156,22 @@ contains
  call meta_rflx(ixRFLX%KWTroutedRunoff  )%init('KWTroutedRunoff'  , 'KWT routed runoff in each reach'     , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
  call meta_rflx(ixRFLX%IRFroutedRunoff  )%init('IRFroutedRunoff'  , 'IRF routed runoff in each reach'     , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
 
- ! Kinematic Wave                    varName      varDesc                                           unit,     varType,     varDim,                                                              writeOut
+ ! Kinematic Wave                    varName      varDesc                                           unit,     varType,     varDim,                                             writeOut
  call meta_kwt(ixKWT%tentry   )%init('tentry'   , 'time when a wave enters a segment'             , 'sec'   , nf90_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
  call meta_kwt(ixKWT%texit    )%init('texit'    , 'time when a wave is expected to exit a segment', 'sec'   , nf90_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
  call meta_kwt(ixKWT%qwave    )%init('qwave'    , 'flow of a wave'                                , 'm2/sec', nf90_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
  call meta_kwt(ixKWT%qwave_mod)%init('qwave_mod', 'modified flow of a wave'                       , 'm2/sec', nf90_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
  call meta_kwt(ixKWT%routed   )%init('routed'   , 'routing flag'                                  , '-'     , nf90_int,    [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
 
- ! Impulse Response Function       varName         varDesc              unit,     varType,     varDim,                                                                  writeOut
+ ! Impulse Response Function       varName         varDesc              unit,     varType,     varDim,                                                 writeOut
  call meta_irf(ixIRF%qfuture)%init('irf_qfuture', 'future flow series', 'm3/sec' ,nf90_double, [ixStateDims%seg,ixStateDims%tdh_irf,ixStateDims%ens] , .true.)
  call meta_irf(ixIRF%irfVol) %init('irf_volume' , 'IRF reach volume'  , 'm3'     ,nf90_double, [ixStateDims%seg,ixStateDims%ens]                     , .true.)
 
- ! Basin Impulse Response Function        varName    varDesc               unit,     varType,     varDim,                                                             writeOut
+ ! Basin Impulse Response Function        varName    varDesc               unit,     varType,     varDim,                                            writeOut
  call meta_irf_bas(ixIRFbas%qfuture)%init('qfuture', 'future flow series', 'm3/sec' ,nf90_double, [ixStateDims%seg,ixStateDims%tdh,ixStateDims%ens], .true.)
- call meta_irf_bas(ixIRFbas%q      )%init('basin_q', 'basin routed flow' , 'm3/sec' ,nf90_double, [ixStateDims%seg,ixStateDims%ens]                , .true.)
+
+ ! reach inflow from basin                varName    varDesc                       unit,     varType,     varDim,                                    writeOut
+ call meta_basinQ(ixBasinQ%q       )%init('basin_q', 'inflow into reach from hru' , 'm3/sec' ,nf90_double, [ixStateDims%seg,ixStateDims%ens]       , .true.)
 
  end subroutine popMetadat
 

--- a/route/build/src/read_restart.f90
+++ b/route/build/src/read_restart.f90
@@ -41,7 +41,6 @@ CONTAINS
  ! local variables
  integer(i4b)                  :: ncidRestart          ! restart netcdf id
  real(dp)                      :: TB(2)                ! 2 element-time bound vector
- type(states)                  :: state(0:2)           ! temporal state data structures -currently 2 river routing scheme + basin IRF routing
  integer(i4b)                  :: nSeg,nens            ! dimenion sizes
  integer(i4b)                  :: ntbound              ! dimenion sizes
  integer(i4b)                  :: ixDim_common(3)      ! custom dimension ID array
@@ -75,6 +74,9 @@ CONTAINS
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  T0=TB(1); T1=TB(2)
 
+ call read_basinQ_state(ierr, cmessage)
+ if(ierr/=0)then; message=trim(message)//trim(cmessage); return;endif
+
  ! routing specific variables
  if (doesBasinRoute == 1) then
    call read_IRFbas_state(ierr, cmessage)
@@ -96,6 +98,64 @@ CONTAINS
 
  CONTAINS
 
+  SUBROUTINE read_basinQ_state(ierr, message1)
+  ! meta data
+  USE globalData, ONLY: meta_basinQ              ! reach inflow from basin at previous time step
+  ! State/flux data structures
+  USE globalData, ONLY: RCHFLX                    ! To get q future for basin IRF and IRF (these should not be in this data strucuture)
+  ! Named variables
+  USE var_lookup, ONLY: ixBasinQ, nVarsBasinQ
+  implicit none
+  ! output
+  integer(i4b), intent(out)     :: ierr           ! error code
+  character(*), intent(out)     :: message1       ! error message
+  ! local variables
+  type(states)                  :: state          ! temporal state data structures
+  integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
+  integer(i4b)                  :: ntdh           ! dimension size
+
+  ! initialize error control
+  ierr=0; message1='read_basinQ_state/'
+
+  allocate(state%var(nVarsBasinQ), stat=ierr, errmsg=cmessage)
+  if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+
+  do iVar=1,nVarsBasinQ
+
+   select case(iVar)
+    case(ixBasinQ%q);       allocate(state%var(iVar)%array_2d_dp(nSeg, nens),       stat=ierr)
+    case default; ierr=20; message1=trim(message1)//'unable to identify basin routing variable index'; return
+   end select
+   if(ierr/=0)then; message1=trim(message1)//'problem allocating space for reach inflow '//trim(meta_basinQ(iVar)%varName); return; endif
+
+  end do
+
+  do iVar=1,nVarsBasinQ
+
+   select case(iVar)
+    case(ixBasinQ%q);       call get_nc(ncidRestart, meta_basinQ(iVar)%varName, state%var(iVar)%array_2d_dp, (/1,1/), (/nSeg,nens/), ierr, cmessage)
+    case default; ierr=20; message1=trim(message1)//'unable to identify previous time step reach inflow variable index for nc writing'; return
+   end select
+   if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+
+  enddo
+
+  do iens=1,nens
+   do iSeg=1,nSeg
+    do iVar=1,nVarsBasinQ
+
+     select case(iVar)
+      case(ixBasinQ%q);       RCHFLX(iens,iSeg)%BASIN_QR(1) = state%var(iVar)%array_2d_dp(iSeg,iens)
+      case default; ierr=20; message1=trim(message1)//'unable to identify previous time step reach inflow variable index'; return
+     end select
+
+    enddo
+   enddo
+  enddo
+
+  END SUBROUTINE read_basinQ_state
+
+
   SUBROUTINE read_IRFbas_state(ierr, message1)
   ! meta data
   USE globalData, ONLY: meta_irf_bas              ! basin IRF routing
@@ -108,6 +168,7 @@ CONTAINS
   integer(i4b), intent(out)     :: ierr           ! error code
   character(*), intent(out)     :: message1       ! error message
   ! local variables
+  type(states)                  :: state          ! temporal state data structures
   integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
   integer(i4b)                  :: ntdh           ! dimension size
 
@@ -117,14 +178,13 @@ CONTAINS
   call get_nc_dim_len(ncidRestart, meta_stateDims(ixStateDims%tdh)%dimName, ntdh, ierr, cmessage)
   if(ierr/=0)then;  message1=trim(message1)//trim(cmessage); return; endif
 
-  allocate(state(0)%var(nVarsIRFbas), stat=ierr, errmsg=cmessage)
+  allocate(state%var(nVarsIRFbas), stat=ierr, errmsg=cmessage)
   if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
   do iVar=1,nVarsIRFbas
 
    select case(iVar)
-    case(ixIRFbas%qfuture); allocate(state(0)%var(iVar)%array_3d_dp(nSeg, ntdh, nens), stat=ierr)
-    case(ixIRFbas%q);       allocate(state(0)%var(iVar)%array_2d_dp(nSeg, nens),       stat=ierr)
+    case(ixIRFbas%qfuture); allocate(state%var(iVar)%array_3d_dp(nSeg, ntdh, nens), stat=ierr)
     case default; ierr=20; message1=trim(message1)//'unable to identify basin routing variable index'; return
    end select
    if(ierr/=0)then; message1=trim(message1)//'problem allocating space for basin IRF routing state '//trim(meta_irf_bas(iVar)%varName); return; endif
@@ -134,8 +194,7 @@ CONTAINS
   do iVar=1,nVarsIRFbas
 
    select case(iVar)
-    case(ixIRFbas%q);       call get_nc(ncidRestart, meta_irf_bas(iVar)%varName, state(0)%var(iVar)%array_2d_dp, (/1,1/), (/nSeg,nens/), ierr, cmessage)
-    case(ixIRFbas%qfuture); call get_nc(ncidRestart, meta_irf_bas(iVar)%varName, state(0)%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,ntdh,nens/), ierr, cmessage)
+    case(ixIRFbas%qfuture); call get_nc(ncidRestart, meta_irf_bas(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,ntdh,nens/), ierr, cmessage)
     case default; ierr=20; message1=trim(message1)//'unable to identify basin IRF variable index for nc writing'; return
    end select
    if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
@@ -151,8 +210,7 @@ CONTAINS
     do iVar=1,nVarsIRFbas
 
      select case(iVar)
-      case(ixIRFbas%q);       RCHFLX(iens,iSeg)%BASIN_QR(1) = state(0)%var(iVar)%array_2d_dp(iSeg,iens)
-      case(ixIRFbas%qfuture); RCHFLX(iens,iSeg)%QFUTURE(:)  = state(0)%var(iVar)%array_3d_dp(iSeg,:,iens)
+      case(ixIRFbas%qfuture); RCHFLX(iens,iSeg)%QFUTURE(:)  = state%var(iVar)%array_3d_dp(iSeg,:,iens)
       case default; ierr=20; message1=trim(message1)//'unable to identify basin IRF state variable index'; return
      end select
 
@@ -174,6 +232,7 @@ CONTAINS
   integer(i4b), intent(out)     :: ierr           ! error code
   character(*), intent(out)     :: message1       ! error message
   ! local variables
+  type(states)                  :: state          ! temporal state data structures
   integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
   integer(i4b), allocatable     :: numQF(:,:)     ! number of future Q time steps for each ensemble and segment
   integer(i4b)                  :: ntdh_irf       ! dimenion sizes
@@ -183,7 +242,7 @@ CONTAINS
   call get_nc_dim_len(ncidRestart, meta_stateDims(ixStateDims%tdh_irf)%dimName, ntdh_irf, ierr, cmessage)
   if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
-  allocate(state(impulseResponseFunc)%var(nVarsIRF), stat=ierr, errmsg=cmessage)
+  allocate(state%var(nVarsIRF), stat=ierr, errmsg=cmessage)
   if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
   allocate(numQF(nens,nSeg), stat=ierr, errmsg=cmessage)
@@ -192,8 +251,8 @@ CONTAINS
   do iVar=1,nVarsIRF
 
    select case(iVar)
-    case(ixIRF%qfuture); allocate(state(impulseResponseFunc)%var(iVar)%array_3d_dp(nSeg, ntdh_irf, nens), stat=ierr)
-    case(ixIRF%irfVol);  allocate(state(impulseResponseFunc)%var(iVar)%array_2d_dp(nSeg, nens), stat=ierr)
+    case(ixIRF%qfuture); allocate(state%var(iVar)%array_3d_dp(nSeg, ntdh_irf, nens), stat=ierr)
+    case(ixIRF%irfVol);  allocate(state%var(iVar)%array_2d_dp(nSeg, nens), stat=ierr)
     case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
    end select
    if(ierr/=0)then; message1=trim(message1)//'problem allocating space for IRF routing state '//trim(meta_irf(iVar)%varName); return; endif
@@ -206,8 +265,8 @@ CONTAINS
   do iVar=1,nVarsIRF
 
    select case(iVar)
-    case(ixIRF%qfuture); call get_nc(ncidRestart, meta_irf(iVar)%varName, state(impulseResponseFunc)%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,ntdh_irf,nens/), ierr, cmessage)
-    case(ixIRF%irfVol);  call get_nc(ncidRestart, meta_irf(iVar)%varName, state(impulseResponseFunc)%var(iVar)%array_2d_dp, (/1,1/), (/nSeg, nens/), ierr, cmessage)
+    case(ixIRF%qfuture); call get_nc(ncidRestart, meta_irf(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,ntdh_irf,nens/), ierr, cmessage)
+    case(ixIRF%irfVol);  call get_nc(ncidRestart, meta_irf(iVar)%varName, state%var(iVar)%array_2d_dp, (/1,1/), (/nSeg, nens/), ierr, cmessage)
     case default; ierr=20; message1=trim(message1)//'unable to identify IRF variable index for nc reading'; return
    end select
    if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
@@ -223,8 +282,8 @@ CONTAINS
     do iVar=1,nVarsIRF
 
      select case(iVar)
-      case(ixIRF%qfuture); RCHFLX(iens,iSeg)%QFUTURE_IRF  = state(impulseResponseFunc)%var(iVar)%array_3d_dp(iSeg,1:numQF(iens,iSeg),iens)
-      case(ixIRF%irfVol);  RCHFLX(iens,iSeg)%REACH_VOL(1) = state(impulseResponseFunc)%var(iVar)%array_2d_dp(iSeg,iens)
+      case(ixIRF%qfuture); RCHFLX(iens,iSeg)%QFUTURE_IRF  = state%var(iVar)%array_3d_dp(iSeg,1:numQF(iens,iSeg),iens)
+      case(ixIRF%irfVol);  RCHFLX(iens,iSeg)%REACH_VOL(1) = state%var(iVar)%array_2d_dp(iSeg,iens)
       case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
      end select
 
@@ -245,7 +304,8 @@ CONTAINS
   implicit none
   integer(i4b), intent(out)     :: ierr           ! error code
   character(*), intent(out)     :: message1       ! error message
-  ! output
+  ! local
+  type(states)                  :: state          ! temporal state data structures
   integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
   integer(i4b)                  :: nwave          ! dimenion sizes
   integer(i4b), allocatable     :: RFvec(:)       ! temporal vector
@@ -253,7 +313,7 @@ CONTAINS
   ! initialize error control
   ierr=0; message1='read_KWT_state/'
 
-  allocate(state(kinematicWave)%var(nVarsKWT), stat=ierr, errmsg=cmessage)
+  allocate(state%var(nVarsKWT), stat=ierr, errmsg=cmessage)
   if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
   allocate(numWaves(nens,nSeg), stat=ierr, errmsg=cmessage)
@@ -266,9 +326,9 @@ CONTAINS
   do iVar=1,nVarsKWT
 
     select case(iVar)
-     case(ixKWT%routed); allocate(state(kinematicWave)%var(iVar)%array_3d_dp(nSeg, nwave, nens), stat=ierr)
+     case(ixKWT%routed); allocate(state%var(iVar)%array_3d_dp(nSeg, nwave, nens), stat=ierr)
      case(ixKWT%tentry, ixKWT%texit, ixKWT%qwave, ixKWT%qwave_mod)
-      allocate(state(kinematicWave)%var(iVar)%array_3d_dp(nSeg, nwave, nens), stat=ierr)
+      allocate(state%var(iVar)%array_3d_dp(nSeg, nwave, nens), stat=ierr)
      case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
     end select
     if(ierr/=0)then; message1=trim(message1)//'problem allocating space for KWT routing state '//trim(meta_kwt(iVar)%varName); return; endif
@@ -281,9 +341,9 @@ CONTAINS
 
     select case(iVar)
      case(ixKWT%routed)
-      call get_nc(ncidRestart, meta_kwt(iVar)%varName, state(kinematicWave)%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nwave,nens/), ierr, cmessage)
+      call get_nc(ncidRestart, meta_kwt(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nwave,nens/), ierr, cmessage)
      case(ixKWT%tentry, ixKWT%texit, ixKWT%qwave, ixKWT%qwave_mod)
-      call get_nc(ncidRestart, meta_kwt(iVar)%varName, state(kinematicWave)%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nwave,nens/), ierr, cmessage)
+      call get_nc(ncidRestart, meta_kwt(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nwave,nens/), ierr, cmessage)
      case default; ierr=20; message1=trim(message)//'unable to identify KWT variable index for nc reading'; return
     end select
    if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
@@ -297,14 +357,14 @@ CONTAINS
     do iVar=1,nVarsKWT
 
      select case(iVar)
-      case(ixKWT%tentry);    KROUTE(iens,iSeg)%KWAVE(0:numWaves(iens,iSeg)-1)%TI = state(kinematicWave)%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
-      case(ixKWT%texit);     KROUTE(iens,iSeg)%KWAVE(0:numWaves(iens,iSeg)-1)%TR = state(kinematicWave)%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
-      case(ixKWT%qwave);     KROUTE(iens,iSeg)%KWAVE(0:numWaves(iens,iSeg)-1)%QF = state(kinematicWave)%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
-      case(ixKWT%qwave_mod); KROUTE(iens,iSeg)%KWAVE(0:numWaves(iens,iSeg)-1)%QM = state(kinematicWave)%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
+      case(ixKWT%tentry);    KROUTE(iens,iSeg)%KWAVE(0:numWaves(iens,iSeg)-1)%TI = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
+      case(ixKWT%texit);     KROUTE(iens,iSeg)%KWAVE(0:numWaves(iens,iSeg)-1)%TR = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
+      case(ixKWT%qwave);     KROUTE(iens,iSeg)%KWAVE(0:numWaves(iens,iSeg)-1)%QF = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
+      case(ixKWT%qwave_mod); KROUTE(iens,iSeg)%KWAVE(0:numWaves(iens,iSeg)-1)%QM = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
       case(ixKWT%routed) ! this is suppposed to be logical variable, but put it as 0 or 1 in double now
        if (allocated(RFvec)) deallocate(RFvec, stat=ierr)
        allocate(RFvec(0:numWaves(iens,iSeg)-1),stat=ierr)
-       RFvec = nint(state(kinematicWave)%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens))
+       RFvec = nint(state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens))
        KROUTE(iens,iSeg)%KWAVE(0:numWaves(iens,iSeg)-1)%RF=.False.
        where (RFvec==1_i4b) KROUTE(iens,iSeg)%KWAVE(0:numWaves(iens,iSeg)-1)%RF=.True.
       case default; ierr=20; message1=trim(message1)//'unable to identify KWT routing state variable index'; return

--- a/route/build/src/var_lookup.f90
+++ b/route/build/src/var_lookup.f90
@@ -138,10 +138,13 @@ MODULE var_lookup
   integer(i4b)     :: KWTroutedRunoff   = integerMissing  ! Lagrangian KWT routed runoff in each reach
   integer(i4b)     :: IRFroutedRunoff   = integerMissing  ! IRF routed runoff in each reach
  endtype iLook_RFLX
+ ! Reach inflow from basin
+ type, public  ::  iLook_basinQ
+  integer(i4b)     :: q              = integerMissing  ! final discharge
+ endtype iLook_basinQ
  ! Basin IRF state/fluxes
  type, public  ::  iLook_IRFbas
   integer(i4b)     :: qfuture        = integerMissing  ! future routed flow
-  integer(i4b)     :: q              = integerMissing  ! final discharge
  endtype iLook_IRFbas
  ! KWT state/fluxes
  type, public  ::  iLook_KWT
@@ -171,7 +174,8 @@ MODULE var_lookup
  type(iLook_RFLX)     ,public,parameter :: ixRFLX      = iLook_RFLX     (1,2,3,4,5,6)
  type(iLook_KWT)      ,public,parameter :: ixKWT       = iLook_KWT      (1,2,3,4,5)
  type(iLook_IRF)      ,public,parameter :: ixIRF       = iLook_IRF      (1,2)
- type(iLook_IRFbas  ) ,public,parameter :: ixIRFbas    = iLook_IRFbas   (1,2)
+ type(iLook_IRFbas  ) ,public,parameter :: ixIRFbas    = iLook_IRFbas   (1)
+ type(iLook_basinQ  ) ,public,parameter :: ixBasinQ    = iLook_basinQ   (1)
  ! ***********************************************************************************************************
  ! ** define size of data vectors
  ! ***********************************************************************************************************
@@ -188,6 +192,7 @@ MODULE var_lookup
  integer(i4b),parameter,public    :: nVarsKWT      = storage_size(ixKWT      )/iLength
  integer(i4b),parameter,public    :: nVarsIRF      = storage_size(ixIRF      )/iLength
  integer(i4b),parameter,public    :: nVarsIRFbas   = storage_size(ixIRFbas   )/iLength
+ integer(i4b),parameter,public    :: nVarsBasinQ   = storage_size(ixBasinQ   )/iLength
  ! ***********************************************************************************************************
 
 END MODULE var_lookup


### PR DESCRIPTION
problem:   When basin routing is turned off and try to restart KWT with restart file written (without basin routing restart information), one of fluxes variable (BASIN_QR) used in KWT is not initialized and get error.  This pull-request fixes this error