### PR TITLE
error message fixed in restart reading routine

### DIFF
--- a/route/build/src/read_restart.f90
+++ b/route/build/src/read_restart.f90
@@ -26,7 +26,7 @@ CONTAINS
                           ierr, message)       ! Output: error control
 
  USE dataTypes,    ONLY: states
- USE globalData,   ONLY: meta_stateDims  ! dimension for state variables
+ USE globalData,   ONLY: meta_stateDims        ! dimension for state variables
  USE var_lookup,   ONLY: ixStateDims, nStateDims
 
  implicit none
@@ -100,7 +100,7 @@ CONTAINS
 
   SUBROUTINE read_basinQ_state(ierr, message1)
   ! meta data
-  USE globalData, ONLY: meta_basinQ              ! reach inflow from basin at previous time step
+  USE globalData, ONLY: meta_basinQ               ! reach inflow from basin at previous time step
   ! State/flux data structures
   USE globalData, ONLY: RCHFLX                    ! To get q future for basin IRF and IRF (these should not be in this data strucuture)
   ! Named variables
@@ -110,6 +110,7 @@ CONTAINS
   integer(i4b), intent(out)     :: ierr           ! error code
   character(*), intent(out)     :: message1       ! error message
   ! local variables
+  character(len=strLen)         :: cmessage1      ! error message of downwind routine
   type(states)                  :: state          ! temporal state data structures
   integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
   integer(i4b)                  :: ntdh           ! dimension size
@@ -117,8 +118,8 @@ CONTAINS
   ! initialize error control
   ierr=0; message1='read_basinQ_state/'
 
-  allocate(state%var(nVarsBasinQ), stat=ierr, errmsg=cmessage)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+  allocate(state%var(nVarsBasinQ), stat=ierr, errmsg=cmessage1)
+  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
   do iVar=1,nVarsBasinQ
 
@@ -126,17 +127,17 @@ CONTAINS
     case(ixBasinQ%q);       allocate(state%var(iVar)%array_2d_dp(nSeg, nens),       stat=ierr)
     case default; ierr=20; message1=trim(message1)//'unable to identify basin routing variable index'; return
    end select
-   if(ierr/=0)then; message1=trim(message1)//'problem allocating space for reach inflow '//trim(meta_basinQ(iVar)%varName); return; endif
+   if(ierr/=0)then; message1=trim(message1)//'problem allocating space for reach inflow:'//trim(meta_basinQ(iVar)%varName); return; endif
 
   end do
 
   do iVar=1,nVarsBasinQ
 
    select case(iVar)
-    case(ixBasinQ%q);       call get_nc(ncidRestart, meta_basinQ(iVar)%varName, state%var(iVar)%array_2d_dp, (/1,1/), (/nSeg,nens/), ierr, cmessage)
+    case(ixBasinQ%q);       call get_nc(ncidRestart, meta_basinQ(iVar)%varName, state%var(iVar)%array_2d_dp, (/1,1/), (/nSeg,nens/), ierr, cmessage1)
     case default; ierr=20; message1=trim(message1)//'unable to identify previous time step reach inflow variable index for nc writing'; return
    end select
-   if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+   if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_basinQ(iVar)%varName); return; endif
 
   enddo
 
@@ -168,6 +169,7 @@ CONTAINS
   integer(i4b), intent(out)     :: ierr           ! error code
   character(*), intent(out)     :: message1       ! error message
   ! local variables
+  character(len=strLen)         :: cmessage1      ! error message of downwind routine
   type(states)                  :: state          ! temporal state data structures
   integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
   integer(i4b)                  :: ntdh           ! dimension size
@@ -175,11 +177,11 @@ CONTAINS
   ! initialize error control
   ierr=0; message1='read_IRFbas_state/'
 
-  call get_nc_dim_len(ncidRestart, meta_stateDims(ixStateDims%tdh)%dimName, ntdh, ierr, cmessage)
-  if(ierr/=0)then;  message1=trim(message1)//trim(cmessage); return; endif
+  call get_nc_dim_len(ncidRestart, meta_stateDims(ixStateDims%tdh)%dimName, ntdh, ierr, cmessage1)
+  if(ierr/=0)then;  message1=trim(message1)//trim(cmessage1); return; endif
 
-  allocate(state%var(nVarsIRFbas), stat=ierr, errmsg=cmessage)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+  allocate(state%var(nVarsIRFbas), stat=ierr, errmsg=cmessage1)
+  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
   do iVar=1,nVarsIRFbas
 
@@ -187,25 +189,25 @@ CONTAINS
     case(ixIRFbas%qfuture); allocate(state%var(iVar)%array_3d_dp(nSeg, ntdh, nens), stat=ierr)
     case default; ierr=20; message1=trim(message1)//'unable to identify basin routing variable index'; return
    end select
-   if(ierr/=0)then; message1=trim(message1)//'problem allocating space for basin IRF routing state '//trim(meta_irf_bas(iVar)%varName); return; endif
+   if(ierr/=0)then; message1=trim(message1)//'problem allocating space for basin IRF routing state:'//trim(meta_irf_bas(iVar)%varName); return; endif
 
   end do
 
   do iVar=1,nVarsIRFbas
 
    select case(iVar)
-    case(ixIRFbas%qfuture); call get_nc(ncidRestart, meta_irf_bas(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,ntdh,nens/), ierr, cmessage)
+    case(ixIRFbas%qfuture); call get_nc(ncidRestart, meta_irf_bas(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,ntdh,nens/), ierr, cmessage1)
     case default; ierr=20; message1=trim(message1)//'unable to identify basin IRF variable index for nc writing'; return
    end select
-   if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+   if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_irf_bas(iVar)%varName); return; endif
 
   enddo
 
   do iens=1,nens
    do iSeg=1,nSeg
 
-    allocate(RCHFLX(iens,iSeg)%QFUTURE(ntdh), stat=ierr, errmsg=cmessage)
-    if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+    allocate(RCHFLX(iens,iSeg)%QFUTURE(ntdh), stat=ierr, errmsg=cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
     do iVar=1,nVarsIRFbas
 
@@ -232,6 +234,7 @@ CONTAINS
   integer(i4b), intent(out)     :: ierr           ! error code
   character(*), intent(out)     :: message1       ! error message
   ! local variables
+  character(len=strLen)         :: cmessage1      ! error message of downwind routine
   type(states)                  :: state          ! temporal state data structures
   integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
   integer(i4b), allocatable     :: numQF(:,:)     ! number of future Q time steps for each ensemble and segment
@@ -239,14 +242,14 @@ CONTAINS
 
   ierr=0; message1='read_IRF_state/'
 
-  call get_nc_dim_len(ncidRestart, meta_stateDims(ixStateDims%tdh_irf)%dimName, ntdh_irf, ierr, cmessage)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+  call get_nc_dim_len(ncidRestart, meta_stateDims(ixStateDims%tdh_irf)%dimName, ntdh_irf, ierr, cmessage1)
+  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
-  allocate(state%var(nVarsIRF), stat=ierr, errmsg=cmessage)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+  allocate(state%var(nVarsIRF), stat=ierr, errmsg=cmessage1)
+  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
-  allocate(numQF(nens,nSeg), stat=ierr, errmsg=cmessage)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+  allocate(numQF(nens,nSeg), stat=ierr, errmsg=cmessage1)
+  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
   do iVar=1,nVarsIRF
 
@@ -255,29 +258,29 @@ CONTAINS
     case(ixIRF%irfVol);  allocate(state%var(iVar)%array_2d_dp(nSeg, nens), stat=ierr)
     case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
    end select
-   if(ierr/=0)then; message1=trim(message1)//'problem allocating space for IRF routing state '//trim(meta_irf(iVar)%varName); return; endif
+   if(ierr/=0)then; message1=trim(message1)//'problem allocating space for IRF routing state:'//trim(meta_irf(iVar)%varName); return; endif
 
   end do
 
-  call get_nc(ncidRestart,'numQF',numQF,(/1,1/),(/nSeg,nens/),ierr,cmessage)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+  call get_nc(ncidRestart,'numQF',numQF,(/1,1/),(/nSeg,nens/),ierr,cmessage1)
+  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_irf(iVar)%varName); return; endif
 
   do iVar=1,nVarsIRF
 
    select case(iVar)
-    case(ixIRF%qfuture); call get_nc(ncidRestart, meta_irf(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,ntdh_irf,nens/), ierr, cmessage)
-    case(ixIRF%irfVol);  call get_nc(ncidRestart, meta_irf(iVar)%varName, state%var(iVar)%array_2d_dp, (/1,1/), (/nSeg, nens/), ierr, cmessage)
+    case(ixIRF%qfuture); call get_nc(ncidRestart, meta_irf(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,ntdh_irf,nens/), ierr, cmessage1)
+    case(ixIRF%irfVol);  call get_nc(ncidRestart, meta_irf(iVar)%varName, state%var(iVar)%array_2d_dp, (/1,1/), (/nSeg, nens/), ierr, cmessage1)
     case default; ierr=20; message1=trim(message1)//'unable to identify IRF variable index for nc reading'; return
    end select
-   if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+   if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_irf(iVar)%varName); return; endif
 
   end do
 
   do iens=1,nens
    do iSeg=1,nSeg
 
-    allocate(RCHFLX(iens,iSeg)%QFUTURE_IRF(numQF(iens,iSeg)), stat=ierr, errmsg=cmessage)
-    if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+    allocate(RCHFLX(iens,iSeg)%QFUTURE_IRF(numQF(iens,iSeg)), stat=ierr, errmsg=cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
     do iVar=1,nVarsIRF
 
@@ -305,6 +308,7 @@ CONTAINS
   integer(i4b), intent(out)     :: ierr           ! error code
   character(*), intent(out)     :: message1       ! error message
   ! local
+  character(len=strLen)         :: cmessage1      ! error message of downwind routine
   type(states)                  :: state          ! temporal state data structures
   integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
   integer(i4b)                  :: nwave          ! dimenion sizes
@@ -313,15 +317,15 @@ CONTAINS
   ! initialize error control
   ierr=0; message1='read_KWT_state/'
 
-  allocate(state%var(nVarsKWT), stat=ierr, errmsg=cmessage)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+  allocate(state%var(nVarsKWT), stat=ierr, errmsg=cmessage1)
+  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
-  allocate(numWaves(nens,nSeg), stat=ierr, errmsg=cmessage)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+  allocate(numWaves(nens,nSeg), stat=ierr, errmsg=cmessage1)
+  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
   ! get Dimension sizes
-  call get_nc_dim_len(ncidRestart, meta_stateDims(ixStateDims%wave)%dimName, nwave, ierr, cmessage)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+  call get_nc_dim_len(ncidRestart, meta_stateDims(ixStateDims%wave)%dimName, nwave, ierr, cmessage1)
+  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
   do iVar=1,nVarsKWT
 
@@ -331,22 +335,22 @@ CONTAINS
       allocate(state%var(iVar)%array_3d_dp(nSeg, nwave, nens), stat=ierr)
      case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
     end select
-    if(ierr/=0)then; message1=trim(message1)//'problem allocating space for KWT routing state '//trim(meta_kwt(iVar)%varName); return; endif
+    if(ierr/=0)then; message1=trim(message1)//'problem allocating space for KWT routing state:'//trim(meta_kwt(iVar)%varName); return; endif
   end do
 
-  call get_nc(ncidRestart,'numWaves',numWaves, (/1,1/), (/nSeg,nens/), ierr, cmessage)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+  call get_nc(ncidRestart,'numWaves',numWaves, (/1,1/), (/nSeg,nens/), ierr, cmessage1)
+  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
   do iVar=1,nVarsKWT
 
     select case(iVar)
      case(ixKWT%routed)
-      call get_nc(ncidRestart, meta_kwt(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nwave,nens/), ierr, cmessage)
+      call get_nc(ncidRestart, meta_kwt(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nwave,nens/), ierr, cmessage1)
      case(ixKWT%tentry, ixKWT%texit, ixKWT%qwave, ixKWT%qwave_mod)
-      call get_nc(ncidRestart, meta_kwt(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nwave,nens/), ierr, cmessage)
-     case default; ierr=20; message1=trim(message)//'unable to identify KWT variable index for nc reading'; return
+      call get_nc(ncidRestart, meta_kwt(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nwave,nens/), ierr, cmessage1)
+     case default; ierr=20; message1=trim(message1)//'unable to identify KWT variable index for nc reading'; return
     end select
-   if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+   if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_kwt(iVar)%varName); return; endif
   end do
 
   do iens=1,nens
@@ -377,6 +381,5 @@ CONTAINS
   END SUBROUTINE read_KWT_state
 
  END SUBROUTINE read_state_nc
-
 
 END MODULE read_restart


### PR DESCRIPTION
- Added `cmessage1` variable in subroutines (e.g., `read_IRFbas_state`) located within` read_state_nc` to fix erroneous messages.

- Include variable name in error message. 