### PR TITLE
added MERIT_Hydro conus NLDAS case for mizuRoute control file build

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -84,6 +84,16 @@ def _create_control_files(case, caseroot, srcroot, confdir, inst_string, infile,
        varname_segId = "seg_id"
        varname_downSegId = "Tosegment"
        varname_pfafCode = "PFAF"
+    elif (  config['rof_grid'] == "MERIT_CONUSmz" ):
+       fname_ntopOld = "ntopo_MERITmz_0.125nldas2_cdf5_fill_reorder_c20210625.nc"
+       varname_area = "Basin_Area"
+       varname_length = "length"
+       varname_slope  = "Slope"
+       varname_HRUid = "hruid"
+       varname_hruSegId = "hru_seg_id"
+       varname_segId = "seg_id"
+       varname_downSegId = "Tosegment"
+       varname_pfafCode = "pfaf"
     elif (  config['rof_grid'] == "USGS_GFmz" ):
        fname_ntopOld = "ntopo_USGS-GFmz_Conus_cdf5_c20201008.nc"
        varname_area = "Basin_Area"


### PR DESCRIPTION
This allows buildnml to update mizuRoute control file (network data information) for running MERIT_Hydro network over 12km NLDAS domain (CLM runs at 12km NLDAS) when you build ctsm-mizuroute.