### PR TITLE
Resolve pio iosystem confusion causing PIO netcdf writing

### DIFF
--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -1,5 +1,6 @@
 module globalData
   ! This module includes shared data
+  USE pio
 
   USE public_var, ONLY: integerMissing
   USE public_var, ONLY: maxDomain
@@ -90,6 +91,8 @@ module globalData
   type(infileinfo) , allocatable , public :: infileinfo_data(:)   ! conversion factor to convert time to units of days
 
   ! ---------- Misc. data -------------------------------------------------------------------------
+  ! standalone mode
+  logical(lgt)                   , public :: isStandalone=.true.       ! flag to indicate model is running in standalone mode (True), otherwise coupled mode
 
   ! I/O stuff
   logical(lgt)                   , public :: isFileOpen                ! flag to indicate output netcdf is open
@@ -111,6 +114,7 @@ module globalData
   integer(i4b)                   , public :: pio_rearranger    = 2     ! 0=>PIO_rearr_none 1=> PIO_rearr_box 2=> PIO_rearr_subset
   integer(i4b)                   , public :: pio_root          = 1
   integer(i4b)                   , public :: pio_stride        = 1
+  type(iosystem_desc_t)          , public :: pioSystem                  ! PIO I/O system data
 
   ! ---------- conversion factors -------------------------------------------------------------------
 

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -23,6 +23,8 @@ USE globalData,        ONLY: pio_numiotasks
 USE globalData,        ONLY: pio_rearranger
 USE globalData,        ONLY: pio_root
 USE globalData,        ONLY: pio_stride
+USE globalData,        ONLY: pioSystem
+USE globalData,        ONLY: isStandalone
 ! Moudle wide external modules
 USE nr_utility_module, ONLY: arth
 USE pio_utils
@@ -32,7 +34,6 @@ implicit none
 ! The following variables used only in this module
 character(300),       save :: fileout              ! name of the output file
 integer(i4b),         save :: jTime                ! time step in output netCDF
-type(iosystem_desc_t),save :: pioSystem            ! PIO I/O system data
 type(file_desc_t),    save :: pioFileDesc          ! PIO data identifying the file
 type(io_desc_t),      save :: iodesc_rch_flx       ! PIO domain decomposition data for reach flux [nRch]
 type(io_desc_t),      save :: iodesc_hru_ro        ! PIO domain decomposition data for hru runoff [nHRU]
@@ -391,11 +392,13 @@ CONTAINS
  end if
 
  ! pio initialization
- pio_numiotasks = nNodes/pio_stride
- call pio_sys_init(pid, mpicom_route,          & ! input: MPI related parameters
-                   pio_stride, pio_numiotasks, & ! input: PIO related parameters
-                   pio_rearranger, pio_root,   & ! input: PIO related parameters
-                   pioSystem)                    ! output: PIO system descriptors
+ if (isStandalone) then
+   pio_numiotasks = nNodes/pio_stride
+   call pio_sys_init(pid, mpicom_route,          & ! input: MPI related parameters
+                     pio_stride, pio_numiotasks, & ! input: PIO related parameters
+                     pio_rearranger, pio_root,   & ! input: PIO related parameters
+                     pioSystem)                    ! output: PIO system descriptors
+ endif
 
  ! For reach flux/volume
  if (masterproc) then


### PR DESCRIPTION
Made pio iosystem initialization optional so that mizuRoute initialize pio iosytem when running in stand-alone mode, while for coupled mode, just use pio iosystem initialized by CIME (coupler).  

This resolves issue #184 