### PR TITLE
time dimension in restart files

### DIFF
--- a/route/build/src/pio_utils.f90
+++ b/route/build/src/pio_utils.f90
@@ -17,6 +17,7 @@ module pio_utils
   public::openFile
   public::closeFile
   public::sync_file
+  public::write_scalar_netcdf      ! write non-distributed data
   public::write_netcdf             ! write non-distributed data
   public::write_pnetcdf            ! write distributed data without record dimension
   public::write_pnetcdf_recdim     ! write distributed data at a specified index of record dimension
@@ -40,18 +41,26 @@ module pio_utils
   public var_desc_t
   public io_desc_t
 
+  interface write_scalar_netcdf
+    module procedure write_int_scalar
+    module procedure write_double_scalar
+    module procedure write_char_scalar
+  end interface
+
   interface write_netcdf
     module procedure write_int_array1D
-    module procedure write_real_array1D
     module procedure write_int_array2D
-    module procedure write_real_array2D
+    module procedure write_double_array1D
+    module procedure write_double_array2D
   end interface
 
   interface write_pnetcdf
     module procedure write_int_darray1D
     module procedure write_int_darray2D
-    module procedure write_real_darray1D
-    module procedure write_real_darray2D
+    module procedure write_int_darray3D
+    module procedure write_double_darray1D
+    module procedure write_double_darray2D
+    module procedure write_double_darray3D
   end interface
 
   interface write_pnetcdf_recdim
@@ -394,9 +403,9 @@ contains
   !-----------------------------------------------------------------------
   subroutine def_var(pioFileDesc,   & ! input: file descriptor
                      vname,         & ! input: variable name
-                     pioDimId,      & ! input: dimension ID(s)
                      ivtype,        & ! input: variable type. pio_int, pio_real, pio_double, pio_char
                      ierr, message, & ! output: error code and message
+                     pioDimId,      & ! input: optional. dimension ID(s)
                      vdesc,         & ! input: optional. long_name
                      vunit,         & ! input: optional. unit
                      vcal)            ! input: optional. calendar type
@@ -404,8 +413,8 @@ contains
   ! input
   type(file_desc_t),intent(inout)         :: pioFileDesc            ! contains data identifying the file.
   character(*),     intent(in)            :: vname                  ! Input: variable name
-  integer(i4b),     intent(in)            :: pioDimId(:)            ! Input: variable dimension IDs
   integer(i4b),     intent(in)            :: ivtype                 ! Input: variable type. pio_int, pio_real, pio_double, pio_char
+  integer(i4b),     intent(in), optional  :: pioDimId(:)            ! Input: variable dimension IDs
   character(*),     intent(in), optional  :: vdesc                  ! Input: variable description
   character(*),     intent(in), optional  :: vunit                  ! Input: variable units
   character(*),     intent(in), optional  :: vcal                   ! Input: calendar (if time variable)
@@ -413,9 +422,16 @@ contains
   integer(i4b),     intent(out)           :: ierr
   character(*),     intent(out)           :: message      ! error message
   ! local variables
+  integer(i4b)                            :: dimid0(1)           ! dimid for no dimension
   type(var_desc_t)                        :: pioVarId
 
-  ierr = pio_def_var(pioFileDesc, trim(vname), ivtype, pioDimId, pioVarId)
+  dimid0 = 0
+
+  if (present(pioDimId)) then
+    ierr = pio_def_var(pioFileDesc, trim(vname), ivtype, pioDimId, pioVarId)
+  else
+    ierr = pio_def_var(pioFileDesc, trim(vname), ivtype, pioVarId)
+  end if
   if(ierr/=pio_noerr)then; message=trim(message)//'Could not define variable'; return; endif
 
   if (present(vdesc)) then ! add long_name
@@ -439,6 +455,87 @@ contains
   ! -----------------------------
   ! Writing routine
   ! -----------------------------
+
+  ! ---------------------------------------------------------------
+  ! write global integer scalar
+  subroutine write_int_scalar(pioFileDesc,     &
+                              vname,           &  ! input: variable name
+                              scalar,          &  ! input: variable data
+                              ierr, message)      ! output: error control
+  implicit none
+  ! input
+  type(file_desc_t),  intent(inout) :: pioFileDesc  ! pio file handle
+  character(*),       intent(in)    :: vname        ! variable name
+  integer(i4b),       intent(in)    :: scalar       ! variable data
+  ! output
+  integer(i4b),       intent(out)   :: ierr
+  character(*),       intent(out)   :: message      ! error message
+  ! local variables
+  type(var_desc_t)                  :: pioVarId
+
+  ierr=0; message='write_int_scalar/'
+
+  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
+  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
+
+  ierr = pio_put_var(pioFileDesc, pioVarId, scalar)
+  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
+
+  end subroutine write_int_scalar
+
+  ! ---------------------------------------------------------------
+  ! write global real scalar
+  subroutine write_double_scalar(pioFileDesc,     &
+                               vname,           &  ! input: variable name
+                               scalar,          &  ! input: variable data
+                               ierr, message)      ! output: error control
+  implicit none
+  ! input
+  type(file_desc_t),  intent(inout) :: pioFileDesc  ! pio file handle
+  character(*),       intent(in)    :: vname        ! variable name
+  real(dp),           intent(in)    :: scalar       ! variable data
+  ! output
+  integer(i4b),       intent(out)   :: ierr
+  character(*),       intent(out)   :: message      ! error message
+  ! local variables
+  type(var_desc_t)                  :: pioVarId
+
+  ierr=0; message='write_double_scalar/'
+
+  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
+  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
+
+  ierr = pio_put_var(pioFileDesc, pioVarId, scalar)
+  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
+
+  end subroutine write_double_scalar
+
+  ! ---------------------------------------------------------------
+  ! write global character scalar
+  subroutine write_char_scalar(pioFileDesc,    &
+                              vname,           &  ! input: variable name
+                              scalar,          &  ! input: variable data
+                              ierr, message)      ! output: error control
+  implicit none
+  ! input
+  type(file_desc_t),  intent(inout) :: pioFileDesc  ! pio file handle
+  character(*),       intent(in)    :: vname        ! variable name
+  character(*),       intent(in)    :: scalar       ! variable data
+  ! output
+  integer(i4b),       intent(out)   :: ierr
+  character(*),       intent(out)   :: message      ! error message
+  ! local variables
+  type(var_desc_t)                  :: pioVarId
+
+  ierr=0; message='write_char_scalar/'
+
+  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
+  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
+
+  ierr = pio_put_var(pioFileDesc, pioVarId, scalar)
+  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
+
+  end subroutine write_char_scalar
 
   ! ---------------------------------------------------------------
   ! write global integer vector into 1D variable
@@ -473,12 +570,12 @@ contains
 
   ! ---------------------------------------------------------------
   ! write global real vector into 1D variable
-  subroutine write_real_array1D(pioFileDesc,     &
-                                vname,           &  ! input: variable name
-                                array,           &  ! input: variable data
-                                iStart,          &  ! input: start index
-                                iCount,          &  ! input: length of vector
-                                ierr, message)      ! output: error control
+  subroutine write_double_array1D(pioFileDesc,    &
+                                 vname,           &  ! input: variable name
+                                 array,           &  ! input: variable data
+                                 iStart,          &  ! input: start index
+                                 iCount,          &  ! input: length of vector
+                                 ierr, message)      ! output: error control
   implicit none
   ! input
   type(file_desc_t),     intent(inout) :: pioFileDesc  ! pio file handle
@@ -492,15 +589,15 @@ contains
   ! local variables
   type(var_desc_t)                     :: pioVarId
 
-  ierr=0; message='write_real_array1D/'
+  ierr=0; message='write_double_array1D/'
 
   ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
   if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
 
-  ierr = pio_put_var(pioFileDesc, pioVarId, iStart, iCount, real(array,kind=sp))
+  ierr = pio_put_var(pioFileDesc, pioVarId, iStart, iCount, array)
   if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
 
-  end subroutine write_real_array1D
+  end subroutine write_double_array1D
 
   ! ---------------------------------------------------------------
   ! write global integer 2D into 2D variable
@@ -535,12 +632,12 @@ contains
 
   ! ---------------------------------------------------------------
   ! write global real 2D into 2D variable
-  subroutine write_real_array2D(pioFileDesc,     &
-                                vname,           &  ! input: variable name
-                                array,           &  ! input: variable data
-                                iStart,          &  ! input: start index
-                                iCount,          &  ! input: length of vector
-                                ierr, message)      ! output: error control
+  subroutine write_double_array2D(pioFileDesc,     &
+                                  vname,           &  ! input: variable name
+                                  array,           &  ! input: variable data
+                                  iStart,          &  ! input: start index
+                                  iCount,          &  ! input: length of vector
+                                  ierr, message)      ! output: error control
   implicit none
   ! input
   type(file_desc_t),     intent(inout) :: pioFileDesc  ! pio file handle
@@ -554,15 +651,15 @@ contains
   ! local variables
   type(var_desc_t)                     :: pioVarId
 
-  ierr=0; message='write_real_array2D/'
+  ierr=0; message='write_double_array2D/'
 
   ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
   if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
 
-  ierr = pio_put_var(pioFileDesc, pioVarId, iStart, iCount, real(array,kind=sp))
+  ierr = pio_put_var(pioFileDesc, pioVarId, iStart, iCount, array)
   if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
 
-  end subroutine write_real_array2D
+  end subroutine write_double_array2D
 
 
   ! ---------------------------------------------------------------
@@ -624,8 +721,37 @@ contains
   end subroutine write_int_darray2D
 
   ! ---------------------------------------------------------------
-  ! write distributed real vector into 1D data
-  subroutine write_real_darray1D(pioFileDesc,     &
+  ! write distributed 3D integer array into 2D variable
+  subroutine write_int_darray3D(pioFileDesc,     &
+                                vname,           &  ! input: variable name
+                                array,           &  ! input: variable data
+                                iodesc,          &  ! input: ??? it is from initdecomp routine
+                                ierr, message)      ! output: error control
+  implicit none
+  ! input variables
+  type(file_desc_t),     intent(inout) :: pioFileDesc  ! pio file handle
+  character(*),          intent(in)    :: vname        ! variable name
+  integer(i4b),          intent(in)    :: array(:,:,:) ! variable data
+  type(io_desc_t),       intent(inout) :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
+  ! output variables
+  integer(i4b),          intent(out)   :: ierr         ! error code
+  character(*),          intent(out)   :: message      ! error message
+  ! local variables
+  type(var_desc_t)                     :: pioVarId     ! netCDF variable ID
+
+  ierr=0; message='write_int_darray3D/'
+
+  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
+  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
+
+  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
+
+  end subroutine write_int_darray3D
+
+  ! ---------------------------------------------------------------
+  ! write distributed double vector into 1D data
+  subroutine write_double_darray1D(pioFileDesc,   &
                                  vname,           &  ! input: variable name
                                  array,           &  ! input: variable data
                                  iodesc,          &  ! input: ??? it is from initdecomp routine
@@ -642,19 +768,19 @@ contains
   ! local variables
   type(var_desc_t)                     :: pioVarId     ! netCDF variable ID
 
-  ierr=0; message='write_real_darray1D/'
+  ierr=0; message='write_double_darray1D/'
 
   ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
   if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
 
-  call pio_write_darray(pioFileDesc, pioVarId, iodesc, real(array,kind=sp), ierr)
+  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
   if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
 
-  end subroutine write_real_darray1D
+  end subroutine write_double_darray1D
 
   ! ---------------------------------------------------------------
-  ! write distributed real 2D integer array into 2D variable
-  subroutine write_real_darray2D(pioFileDesc,     &
+  ! write distributed double 2D integer array into 2D variable
+  subroutine write_double_darray2D(pioFileDesc,   &
                                  vname,           &  ! input: variable name
                                  array,           &  ! input: variable data
                                  iodesc,          &  ! input: ??? it is from initdecomp routine
@@ -671,15 +797,44 @@ contains
   ! local variables
   type(var_desc_t)                      :: pioVarId     ! netCDF variable ID
 
-  ierr=0; message='write_real_darray2D/'
+  ierr=0; message='write_double_darray2D/'
 
   ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
   if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
 
-  call pio_write_darray(pioFileDesc, pioVarId, iodesc, real(array,kind=sp), ierr)
+  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
   if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
 
-  end subroutine write_real_darray2D
+  end subroutine write_double_darray2D
+
+  ! ---------------------------------------------------------------
+  ! write distributed double 3D integer array into 2D variable
+  subroutine write_double_darray3D(pioFileDesc,   &
+                                 vname,           &  ! input: variable name
+                                 array,           &  ! input: variable data
+                                 iodesc,          &  ! input: ??? it is from initdecomp routine
+                                 ierr, message)      ! output: error control
+  implicit none
+  ! input variables
+  type(file_desc_t),     intent(inout)  :: pioFileDesc  ! pio file handle
+  character(*),          intent(in)     :: vname        ! variable name
+  real(dp),              intent(in)     :: array(:,:,:) ! variable data
+  type(io_desc_t),       intent(inout)  :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
+  ! output variables
+  integer(i4b),          intent(out)    :: ierr         ! error code
+  character(*),          intent(out)    :: message      ! error message
+  ! local variables
+  type(var_desc_t)                      :: pioVarId     ! netCDF variable ID
+
+  ierr=0; message='write_double_darray3D/'
+
+  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
+  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
+
+  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
+
+  end subroutine write_double_darray3D
 
   !
   ! Writing distributed data in nc variable with record dimension

--- a/route/build/src/popMetadat.f90
+++ b/route/build/src/popMetadat.f90
@@ -204,26 +204,26 @@ contains
  call meta_rflx(ixRFLX%IRFroutedRunoff  )%init('IRFroutedRunoff'  , 'IRF routed runoff in each reach'     , 'm3/s', pio_real, [ixQdims%seg,ixQdims%time], .true.)
  call meta_rflx(ixRFLX%IRFlakeVol       )%init('IRFlakeVol'       , 'lake and stream volume for IRF'      , 'm3'  , pio_real, [ixQdims%seg,ixQdims%time], .true.)
 
- ! Lagrangian Kinematic Wave         varName      varDesc                                           unit,   varType,    varDim,                                                              writeOut
- call meta_kwt(ixKWT%tentry   )%init('tentry'   , 'time when a wave enters a segment'             , 's'   , pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens,ixStateDims%time], .true.)
- call meta_kwt(ixKWT%texit    )%init('texit'    , 'time when a wave is expected to exit a segment', 's'   , pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens,ixStateDims%time], .true.)
- call meta_kwt(ixKWT%qwave    )%init('qwave'    , 'flow of a wave'                                , 'm2/s', pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens,ixStateDims%time], .true.)
- call meta_kwt(ixKWT%qwave_mod)%init('qwave_mod', 'modified flow of a wave'                       , 'm2/s', pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens,ixStateDims%time], .true.)
- call meta_kwt(ixKWT%routed   )%init('routed'   , 'routing flag'                                  , '-'   , pio_int,    [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens,ixStateDims%time], .true.)
+ ! Lagrangian Kinematic Wave         varName      varDesc                                           unit,   varType,    varDim,                                             writeOut
+ call meta_kwt(ixKWT%tentry   )%init('tentry'   , 'time when a wave enters a segment'             , 's'   , pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
+ call meta_kwt(ixKWT%texit    )%init('texit'    , 'time when a wave is expected to exit a segment', 's'   , pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
+ call meta_kwt(ixKWT%qwave    )%init('qwave'    , 'flow of a wave'                                , 'm2/s', pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
+ call meta_kwt(ixKWT%qwave_mod)%init('qwave_mod', 'modified flow of a wave'                       , 'm2/s', pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
+ call meta_kwt(ixKWT%routed   )%init('routed'   , 'routing flag'                                  , '-'   , pio_int,    [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
 
- ! Eulerian Kinematic Wave       varName      varDesc                       unit,   varType,    varDim,                                                              writeOut
- call meta_kwe(ixKWE%a   )%init('flow_area', 'flow area'                  , 'm2'  , pio_double, [ixStateDims%seg,ixStateDims%fdmesh,ixStateDims%ens,ixStateDims%time], .true.)
- call meta_kwe(ixKWE%q   )%init('kwe_q'    , 'Kinematic wave routed flow' , 'm2/s', pio_double, [ixStateDims%seg,ixStateDims%fdmesh,ixStateDims%ens,ixStateDims%time], .true.)
+ ! Eulerian Kinematic Wave       varName      varDesc                       unit,   varType,    varDim,                                               writeOut
+ call meta_kwe(ixKWE%a   )%init('flow_area', 'flow area'                  , 'm2'  , pio_double, [ixStateDims%seg,ixStateDims%fdmesh,ixStateDims%ens], .true.)
+ call meta_kwe(ixKWE%q   )%init('kwe_q'    , 'Kinematic wave routed flow' , 'm2/s', pio_double, [ixStateDims%seg,ixStateDims%fdmesh,ixStateDims%ens], .true.)
 
- ! Impulse Response Function       varName         varDesc              unit,   varType,    varDim,                                                                  writeOut
- call meta_irf(ixIRF%qfuture)%init('irf_qfuture', 'future flow series',   'm3/s' ,pio_double, [ixStateDims%seg,ixStateDims%tdh_irf,ixStateDims%ens,ixStateDims%time] , .true.)
- call meta_irf(ixIRF%irfVol)%init ('irfVol'     , 'volume in reach/lake', 'm3'   ,pio_double, [ixStateDims%seg,ixStateDims%tbound, ixStateDims%ens,ixStateDims%time] , .true.)
+ ! Impulse Response Function       varName         varDesc              unit,   varType,    varDim,                                                   writeOut
+ call meta_irf(ixIRF%qfuture)%init('irf_qfuture', 'future flow series',   'm3/s' ,pio_double, [ixStateDims%seg,ixStateDims%tdh_irf,ixStateDims%ens] , .true.)
+ call meta_irf(ixIRF%irfVol)%init ('irfVol'     , 'volume in reach/lake', 'm3'   ,pio_double, [ixStateDims%seg,ixStateDims%tbound, ixStateDims%ens] , .true.)
 
- ! Basin Impulse Response Function        varName    varDesc               unit,   varType,    varDim,                                                             writeOut
- call meta_irf_bas(ixIRFbas%qfuture)%init('qfuture', 'future flow series', 'm3/s' ,pio_double, [ixStateDims%seg,ixStateDims%tdh,ixStateDims%ens,ixStateDims%time], .true.)
+ ! Basin Impulse Response Function        varName    varDesc               unit,   varType,    varDim,                                           writeOut
+ call meta_irf_bas(ixIRFbas%qfuture)%init('qfuture', 'future flow series', 'm3/s' ,pio_double, [ixStateDims%seg,ixStateDims%tdh,ixStateDims%ens], .true.)
 
-! reach inflow from basin                 varName     varDesc              unit,  varType,     varDim,                                                             writeOut
- call meta_basinQ(ixBasinQ%q      )%init('basin_q', 'basin routed flow' , 'm3/s' ,pio_double, [ixStateDims%seg,ixStateDims%ens,ixStateDims%time]                , .true.)
+! reach inflow from basin                 varName     varDesc              unit,  varType,     varDim,                                           writeOut
+ call meta_basinQ(ixBasinQ%q      )%init('basin_q', 'basin routed flow' , 'm3/s' ,pio_double, [ixStateDims%seg,ixStateDims%ens]                , .true.)
 
  end subroutine popMetadat
 

--- a/route/build/src/read_restart.f90
+++ b/route/build/src/read_restart.f90
@@ -44,23 +44,22 @@ CONTAINS
  ! local variables
  real(dp)                      :: TB(2)                ! 2 element-time bound vector
  integer(i4b)                  :: nSeg,nens            ! dimenion sizes
- integer(i4b)                  :: nTime,ntbound        ! dimenion sizes
- integer(i4b)                  :: ixDim_common(4)      ! custom dimension ID array
+ integer(i4b)                  :: ntbound              ! dimenion sizes
+ integer(i4b)                  :: ixDim_common(3)      ! custom dimension ID array
  integer(i4b)                  :: jDim                 ! index loops for dimension
  character(len=strLen)         :: cmessage             ! error message of downwind routine
 
  ierr=0; message='read_state_nc/'
 
  ! get Dimension sizes
- ! For common dimension/variables - seg id, time, time-bound -----------
- ixDim_common = (/ixStateDims%seg, ixStateDims%ens, ixStateDims%time, ixStateDims%tbound/)
+ ! For common dimension/variables - seg id, time-bound -----------
+ ixDim_common = (/ixStateDims%seg, ixStateDims%ens, ixStateDims%tbound/)
 
  do jDim=1,size(ixDim_common)
    associate (ixDim_tmp => ixDim_common(jDim))
    select case(ixDim_tmp)
     case(ixStateDims%seg);     call get_nc_dim_len(fname, trim(meta_stateDims(ixDim_tmp)%dimName), nSeg,    ierr, cmessage)
     case(ixStateDims%ens);     call get_nc_dim_len(fname, trim(meta_stateDims(ixDim_tmp)%dimName), nens,    ierr, cmessage)
-    case(ixStateDims%time);    call get_nc_dim_len(fname, trim(meta_stateDims(ixDim_tmp)%dimName), nTime,   ierr, cmessage)
     case(ixStateDims%tbound);  call get_nc_dim_len(fname, trim(meta_stateDims(ixDim_tmp)%dimName), ntbound, ierr, cmessage)
     case default; ierr=20; message=trim(message)//'unable to identify dimension name index'; return
    end select

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -84,7 +84,6 @@ CONTAINS
  ! *********************************************************************
  SUBROUTINE new_file_alarm(newFileAlarm, ierr, message)
 
-   USE public_var,        ONLY: calendar
    USE public_var,        ONLY: newFileFrequency  ! frequency for new output files (day, month, annual, single)
    USE globalData,        ONLY: simDatetime       ! previous and current model time
 
@@ -93,8 +92,6 @@ CONTAINS
    logical(lgt),   intent(out)          :: newFileAlarm     ! logical to make alarm for creating new output file
    integer(i4b),   intent(out)          :: ierr             ! error code
    character(*),   intent(out)          :: message          ! error message
-   ! local variables
-   character(len=strLen)                :: cmessage         ! error message of downwind routine
 
    ierr=0; message='new_file_alarm/'
 
@@ -437,16 +434,17 @@ CONTAINS
  ! define coordinate variable for time
  call def_var(pioFileDesc,                                &                                        ! pio file descriptor
              trim(meta_qDims(ixQdims%time)%dimName),      &                                        ! variable name
-             [meta_qDims(ixQdims%time)%dimId], ncd_float, &                                        ! dimension array and type
+             ncd_float,                                   &                                        ! variable type
              ierr, cmessage,                              &                                        ! error handle
+             pioDimId=[meta_qDims(ixQdims%time)%dimId],   &                                        ! dimension array
              vdesc=trim(meta_qDims(ixQdims%time)%dimName), vunit=trim(units_time), vcal=calendar)  ! optional attributes
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  ! define hru ID and reach ID variables
- call def_var(pioFileDesc, 'basinID', [meta_qDims(ixQdims%hru)%dimId], ncd_int, ierr, cmessage, vdesc='basin ID', vunit='-')
+ call def_var(pioFileDesc, 'basinID', ncd_int, ierr, cmessage, pioDimId=[meta_qDims(ixQdims%hru)%dimId], vdesc='basin ID', vunit='-')
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- call def_var(pioFileDesc, 'reachID', [meta_qDims(ixQdims%seg)%dimId], ncd_int, ierr, cmessage, vdesc='reach ID', vunit='-')
+ call def_var(pioFileDesc, 'reachID', ncd_int, ierr, cmessage, pioDimId=[meta_qDims(ixQdims%seg)%dimId], vdesc='reach ID', vunit='-')
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  ! define flux variables
@@ -467,8 +465,9 @@ CONTAINS
   ! define variable
   call def_var(pioFileDesc,            &                 ! pio file descriptor
               meta_rflx(iVar)%varName, &                 ! variable name
-              dim_array, ncd_float,    &                 ! dimension array and type
+              ncd_float,               &                 ! dimension array and type
               ierr, cmessage,          &                 ! error handling
+              pioDimId=dim_array,      &                 ! dimension id
               vdesc=meta_rflx(iVar)%varDesc, vunit=meta_rflx(iVar)%varUnit)
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 


### PR DESCRIPTION
**remove time dimension (also record dimension) from restart file** 
- popMetadat.f90
- read_restart.f90
- write_restart_pio.f90 

**pio_utility (pio_utils.f90) update**
- added scalar writing
- dimension input argument is optional for def_var routine (not dimension argument become scalar variable)
- add more distributed array writing routines (write_pnetcdf) with higher dimensions 
 
**write restart time in restart file**
- write_restart_pio.f90 (write time variables at restart time with calendar and time unit)